### PR TITLE
Add CsvGenerator.Feature.ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -38,7 +38,7 @@ public class CsvGenerator extends GeneratorBase
          *<p>
          * Default value is <code>false</code> for "loose" (approximate, conservative)
          * checking.
-         *
+         * 
          * @since 2.4
          */
         STRICT_CHECK_FOR_QUOTING(false),
@@ -49,7 +49,7 @@ public class CsvGenerator extends GeneratorBase
          * If <code>true</code>, values and separators between values may be omitted, to slightly reduce
          * length of the row; if <code>false</code>, separators need to stay in place and values
          * are indicated by empty Strings.
-         *
+         * 
          * @since 2.4
          */
         OMIT_MISSING_TAIL_COLUMNS(false),
@@ -84,7 +84,7 @@ public class CsvGenerator extends GeneratorBase
 
         protected final boolean _defaultState;
         protected final int _mask;
-
+        
         /**
          * Method that calculates bit set (flags) of all features that
          * are enabled by default.
@@ -115,7 +115,7 @@ public class CsvGenerator extends GeneratorBase
 
     protected final static long MIN_INT_AS_LONG = Integer.MIN_VALUE;
     protected final static long MAX_INT_AS_LONG = Integer.MAX_VALUE;
-
+    
     /*
     /**********************************************************
     /* Configuration
@@ -126,7 +126,7 @@ public class CsvGenerator extends GeneratorBase
     static {
         EMPTY_SCHEMA = CsvSchema.emptySchema();
     }
-
+    
     final protected IOContext _ioContext;
 
     /**
@@ -156,7 +156,7 @@ public class CsvGenerator extends GeneratorBase
      * instance is constructed.
      */
     protected boolean _handleFirstLine = true;
-
+    
     /**
      * Index of column that we will be getting next, based on
      * field name call that was made.
@@ -229,11 +229,11 @@ public class CsvGenerator extends GeneratorBase
         _writer = csvWriter;
     }
 
-    /*
-    /**********************************************************
-    /* Versioned
-    /**********************************************************
-     */
+    /*                                                                                       
+    /**********************************************************                              
+    /* Versioned                                                                             
+    /**********************************************************                              
+    */
 
     @Override
     public Version version() {
@@ -320,7 +320,7 @@ public class CsvGenerator extends GeneratorBase
     public boolean canUseSchema(FormatSchema schema) {
         return (schema instanceof CsvSchema);
     }
-
+    
     @Override
     public boolean canOmitFields() {
         // Nope: CSV requires at least a placeholder
@@ -335,7 +335,7 @@ public class CsvGenerator extends GeneratorBase
     /* Overridden methods; writing field names
     /**********************************************************************
      */
-
+    
     /* And then methods overridden to make final, streamline some
      * aspects...
      */
@@ -436,7 +436,7 @@ public class CsvGenerator extends GeneratorBase
     public final void flush() throws IOException {
         _writer.flush(isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM));
     }
-
+    
     @Override
     public void close() throws IOException
     {
@@ -444,7 +444,7 @@ public class CsvGenerator extends GeneratorBase
 
         // Let's mark row as closed, if we had any...
         finishRow();
-
+        
         // Write the header if necessary, occurs when no rows written
         if (_handleFirstLine) {
             _handleFirstLine();
@@ -472,7 +472,7 @@ public class CsvGenerator extends GeneratorBase
             } else if (!_skipValue) {
                 // First: column may have its own separator
                 String sep;
-
+                
                 if (_nextColumnByName >= 0) {
                     CsvSchema.Column col = _schema.column(_nextColumnByName);
                     sep = col.isArray() ? col.getArrayElementSeparator() : CsvSchema.NO_ARRAY_ELEMENT_SEPARATOR;
@@ -803,7 +803,7 @@ public class CsvGenerator extends GeneratorBase
             }
         }
     }
-
+    
     @Override
     public void writeNumber(double v) throws IOException
     {
@@ -815,7 +815,7 @@ public class CsvGenerator extends GeneratorBase
                 _writer.write(_columnIndex(), v);
             }
         }
-    }
+    }    
 
     @Override
     public void writeNumber(float v) throws IOException
@@ -865,7 +865,7 @@ public class CsvGenerator extends GeneratorBase
             }
         }
     }
-
+    
     /*
     /**********************************************************
     /* Overrides for field methods
@@ -898,7 +898,7 @@ public class CsvGenerator extends GeneratorBase
     /* Implementations for methods from base class
     /**********************************************************
      */
-
+    
     @Override
     protected final void _verifyValueWrite(String typeMsg) throws IOException
     {
@@ -925,7 +925,7 @@ public class CsvGenerator extends GeneratorBase
     /**
      * Method called when there is a problem related to mapping data
      * (compared to a low-level generation); if so, should be surfaced
-     * as
+     * as 
      *
      * @since 2.7
      */
@@ -965,7 +965,7 @@ public class CsvGenerator extends GeneratorBase
         _handleFirstLine = false;
         if (_schema.usesHeader()) {
             int count = _schema.size();
-            if (count == 0) {
+            if (count == 0) { 
                 _reportMappingError("Schema specified that header line is to be written; but contains no column names");
             }
             for (CsvSchema.Column column : _schema) {
@@ -974,7 +974,7 @@ public class CsvGenerator extends GeneratorBase
             _writer.endRow();
         }
     }
-
+    
     protected void _addToArray(String value) {
         if (_arrayElements > 0) {
             _arrayContents.append(_arraySeparator);

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -228,12 +228,12 @@ public class CsvGenerator extends GeneratorBase
         _formatFeatures = csvFeatures;
         _writer = csvWriter;
     }
-
+    
     /*                                                                                       
     /**********************************************************                              
     /* Versioned                                                                             
     /**********************************************************                              
-    */
+     */
 
     @Override
     public Version version() {
@@ -974,7 +974,7 @@ public class CsvGenerator extends GeneratorBase
             _writer.endRow();
         }
     }
-    
+
     protected void _addToArray(String value) {
         if (_arrayElements > 0) {
             _arrayContents.append(_arraySeparator);
@@ -982,7 +982,7 @@ public class CsvGenerator extends GeneratorBase
         ++_arrayElements;
         _arrayContents.append(value);
     }
-
+    
     protected void _addToArray(char[] value) {
         if (_arrayElements > 0) {
             _arrayContents.append(_arraySeparator);

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -38,7 +38,7 @@ public class CsvGenerator extends GeneratorBase
          *<p>
          * Default value is <code>false</code> for "loose" (approximate, conservative)
          * checking.
-         * 
+         *
          * @since 2.4
          */
         STRICT_CHECK_FOR_QUOTING(false),
@@ -49,7 +49,7 @@ public class CsvGenerator extends GeneratorBase
          * If <code>true</code>, values and separators between values may be omitted, to slightly reduce
          * length of the row; if <code>false</code>, separators need to stay in place and values
          * are indicated by empty Strings.
-         * 
+         *
          * @since 2.4
          */
         OMIT_MISSING_TAIL_COLUMNS(false),
@@ -72,11 +72,19 @@ public class CsvGenerator extends GeneratorBase
          * @since 2.9
          */
         ALWAYS_QUOTE_EMPTY_STRINGS(false),
+
+        /**
+         * Feature that determines whether values written Strings (from <code>java.lang.String</code>
+         * valued POJO properties) which contains quotes be escaped using the Schema's configured escape character instead of "".
+         *
+         * @since 2.9
+         */
+        ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR(false)
         ;
 
         protected final boolean _defaultState;
         protected final int _mask;
-        
+
         /**
          * Method that calculates bit set (flags) of all features that
          * are enabled by default.
@@ -107,7 +115,7 @@ public class CsvGenerator extends GeneratorBase
 
     protected final static long MIN_INT_AS_LONG = Integer.MIN_VALUE;
     protected final static long MAX_INT_AS_LONG = Integer.MAX_VALUE;
-    
+
     /*
     /**********************************************************
     /* Configuration
@@ -118,7 +126,7 @@ public class CsvGenerator extends GeneratorBase
     static {
         EMPTY_SCHEMA = CsvSchema.emptySchema();
     }
-    
+
     final protected IOContext _ioContext;
 
     /**
@@ -148,7 +156,7 @@ public class CsvGenerator extends GeneratorBase
      * instance is constructed.
      */
     protected boolean _handleFirstLine = true;
-    
+
     /**
      * Index of column that we will be getting next, based on
      * field name call that was made.
@@ -220,11 +228,11 @@ public class CsvGenerator extends GeneratorBase
         _formatFeatures = csvFeatures;
         _writer = csvWriter;
     }
-    
-    /*                                                                                       
-    /**********************************************************                              
-    /* Versioned                                                                             
-    /**********************************************************                              
+
+    /*
+    /**********************************************************
+    /* Versioned
+    /**********************************************************
      */
 
     @Override
@@ -312,7 +320,7 @@ public class CsvGenerator extends GeneratorBase
     public boolean canUseSchema(FormatSchema schema) {
         return (schema instanceof CsvSchema);
     }
-    
+
     @Override
     public boolean canOmitFields() {
         // Nope: CSV requires at least a placeholder
@@ -327,7 +335,7 @@ public class CsvGenerator extends GeneratorBase
     /* Overridden methods; writing field names
     /**********************************************************************
      */
-    
+
     /* And then methods overridden to make final, streamline some
      * aspects...
      */
@@ -428,7 +436,7 @@ public class CsvGenerator extends GeneratorBase
     public final void flush() throws IOException {
         _writer.flush(isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM));
     }
-    
+
     @Override
     public void close() throws IOException
     {
@@ -436,7 +444,7 @@ public class CsvGenerator extends GeneratorBase
 
         // Let's mark row as closed, if we had any...
         finishRow();
-        
+
         // Write the header if necessary, occurs when no rows written
         if (_handleFirstLine) {
             _handleFirstLine();
@@ -464,7 +472,7 @@ public class CsvGenerator extends GeneratorBase
             } else if (!_skipValue) {
                 // First: column may have its own separator
                 String sep;
-                
+
                 if (_nextColumnByName >= 0) {
                     CsvSchema.Column col = _schema.column(_nextColumnByName);
                     sep = col.isArray() ? col.getArrayElementSeparator() : CsvSchema.NO_ARRAY_ELEMENT_SEPARATOR;
@@ -795,7 +803,7 @@ public class CsvGenerator extends GeneratorBase
             }
         }
     }
-    
+
     @Override
     public void writeNumber(double v) throws IOException
     {
@@ -807,7 +815,7 @@ public class CsvGenerator extends GeneratorBase
                 _writer.write(_columnIndex(), v);
             }
         }
-    }    
+    }
 
     @Override
     public void writeNumber(float v) throws IOException
@@ -857,7 +865,7 @@ public class CsvGenerator extends GeneratorBase
             }
         }
     }
-    
+
     /*
     /**********************************************************
     /* Overrides for field methods
@@ -890,7 +898,7 @@ public class CsvGenerator extends GeneratorBase
     /* Implementations for methods from base class
     /**********************************************************
      */
-    
+
     @Override
     protected final void _verifyValueWrite(String typeMsg) throws IOException
     {
@@ -917,7 +925,7 @@ public class CsvGenerator extends GeneratorBase
     /**
      * Method called when there is a problem related to mapping data
      * (compared to a low-level generation); if so, should be surfaced
-     * as 
+     * as
      *
      * @since 2.7
      */
@@ -957,7 +965,7 @@ public class CsvGenerator extends GeneratorBase
         _handleFirstLine = false;
         if (_schema.usesHeader()) {
             int count = _schema.size();
-            if (count == 0) { 
+            if (count == 0) {
                 _reportMappingError("Schema specified that header line is to be written; but contains no column names");
             }
             for (CsvSchema.Column column : _schema) {
@@ -974,7 +982,7 @@ public class CsvGenerator extends GeneratorBase
         ++_arrayElements;
         _arrayContents.append(value);
     }
-    
+
     protected void _addToArray(char[] value) {
         if (_arrayElements > 0) {
             _arrayContents.append(_arraySeparator);

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -24,12 +24,12 @@ public class CsvEncoder
      * values; longer ones will always be quoted.
      */
     final protected static int MAX_QUOTE_CHECK = 24;
-
+    
     final protected BufferedValue[] NO_BUFFERED = new BufferedValue[0];
 
     private final static char[] TRUE_CHARS = "true".toCharArray();
     private final static char[] FALSE_CHARS = "false".toCharArray();
-
+    
     /*
     /**********************************************************
     /* Configuration
@@ -42,7 +42,7 @@ public class CsvEncoder
      * Underlying {@link Writer} used for output.
      */
     final protected Writer _out;
-
+    
     final protected char _cfgColumnSeparator;
 
     final protected int _cfgQuoteCharacter;
@@ -51,18 +51,18 @@ public class CsvEncoder
      * @since 2.7
      */
     final protected int _cfgEscapeCharacter;
-
+    
     final protected char[] _cfgLineSeparator;
 
     /**
      * @since 2.5
      */
     final protected char[] _cfgNullValue;
-
+    
     final protected int _cfgLineSeparatorLength;
 
     protected int _cfgMaxQuoteCheckChars;
-
+    
     /**
      * Lowest-valued character that is safe to output without using
      * quotes around value, NOT including possible escape character.
@@ -74,7 +74,7 @@ public class CsvEncoder
     /**
      * Marker flag used to determine if to do optimal (aka "strict") quoting
      * checks or not (looser conservative check)
-     *
+     * 
      * @since 2.4
      */
     protected boolean _cfgOptimalQuoting;
@@ -105,14 +105,14 @@ public class CsvEncoder
      * @since 2.4
      */
     protected int _columnCount;
-
+    
     /**
      * Index of column we expect to write next
      */
     protected int _nextColumnToWrite = 0;
 
     /**
-     * And if output comes in shuffled order we will need to do
+     * And if output comes in shuffled order we will need to do 
      * bit of ordering.
      */
     protected BufferedValue[] _buffered = NO_BUFFERED;
@@ -121,7 +121,7 @@ public class CsvEncoder
      * Index of the last buffered value
      */
     protected int _lastBuffered = -1;
-
+    
     /*
     /**********************************************************
     /* Output buffering, low-level
@@ -139,7 +139,7 @@ public class CsvEncoder
      * needs to be returned to recycler once we are done) or not.
      */
     protected boolean _bufferRecyclable;
-
+    
     /**
      * Pointer to the next available char position in {@link #_outputBuffer}
      */
@@ -150,7 +150,7 @@ public class CsvEncoder
      * Typically same as length of the buffer.
      */
     protected final int _outputEnd;
-
+    
     /**
      * Let's keep track of how many bytes have been output, may prove useful
      * when debugging. This does <b>not</b> include bytes buffered in
@@ -158,7 +158,7 @@ public class CsvEncoder
      * stream writer.
      */
     protected int _charsWritten;
-
+    
     /*
     /**********************************************************
     /* Construction, (re)configuration
@@ -186,7 +186,7 @@ public class CsvEncoder
         _cfgLineSeparator = schema.getLineSeparator();
         _cfgLineSeparatorLength = (_cfgLineSeparator == null) ? 0 : _cfgLineSeparator.length;
         _cfgNullValue = schema.getNullValueOrEmpty();
-
+        
         _columnCount = schema.size();
 
         _cfgMinSafeChar = _calcSafeChar();
@@ -424,7 +424,7 @@ public class CsvEncoder
         }
         _buffer(columnIndex, BufferedValue.bufferedRaw(rawValue));
     }
-
+        
     public final void writeNull(int columnIndex) throws IOException
     {
         if (columnIndex == _nextColumnToWrite) {
@@ -456,7 +456,7 @@ public class CsvEncoder
                     // note: write method triggers prepending of separator; but for missing
                     // values we need to do it explicitly.
                     appendColumnSeparator();
-                }
+                } 
             }
         } else if (_nextColumnToWrite <= 0) { // empty line; do nothing
             return;
@@ -477,7 +477,7 @@ public class CsvEncoder
         System.arraycopy(_cfgLineSeparator, 0, _outputBuffer, _outputTail, _cfgLineSeparatorLength);
         _outputTail += _cfgLineSeparatorLength;
     }
-
+    
     /*
     /**********************************************************
     /* Writer API, writes via buffered values
@@ -589,7 +589,7 @@ public class CsvEncoder
         }
         _outputTail += len;
     }
-
+    
     protected void appendColumnSeparator() throws IOException {
         if (_outputTail >= _outputEnd) {
             _flushBuffer();
@@ -602,7 +602,7 @@ public class CsvEncoder
     /* Output methods, unprocessed ("raw")
     /**********************************************************
      */
-
+    
     public void writeRaw(String text) throws IOException
     {
         // Nothing to check, can just output as is
@@ -635,7 +635,7 @@ public class CsvEncoder
         if (room >= len) {
             text.getChars(start, start+len, _outputBuffer, _outputTail);
             _outputTail += len;
-        } else {
+        } else {                
             writeRawLong(text.substring(start, start+len));
         }
     }
@@ -718,7 +718,7 @@ public class CsvEncoder
         text.getChars(0, len, buf, ptr);
 
         final int end = ptr+len;
-
+        
         for (; ptr < end && buf[ptr] != q; ++ptr) { }
 
         if (ptr == end) { // all good, no quoting or escaping!
@@ -832,7 +832,7 @@ public class CsvEncoder
         }
         buf[_outputTail++] = q;
     }
-
+    
     private final void _writeLongQuotedAndEscaped(String text, char esc) throws IOException
     {
         final int len = text.length();
@@ -863,7 +863,7 @@ public class CsvEncoder
     /* Writer API, state changes
     /**********************************************************
      */
-
+    
     public void flush(boolean flushStream) throws IOException
     {
         _flushBuffer();
@@ -884,7 +884,7 @@ public class CsvEncoder
         // Internal buffer(s) generator has can now be released as well
         _releaseBuffers();
     }
-
+    
     /*
     /**********************************************************
     /* Internal methods
@@ -924,7 +924,7 @@ public class CsvEncoder
      *<p>
      * NOTE: final since checking is not expected to be changed here; override
      * calling method (<code>_mayNeedQuotes</code>) instead, if necessary.
-     *
+     * 
      * @since 2.4
      */
     protected final boolean _needsQuotingLoose(String value)
@@ -947,7 +947,7 @@ public class CsvEncoder
         }
         return false;
     }
-
+    
     /**
      * @since 2.4
      */
@@ -989,7 +989,7 @@ public class CsvEncoder
         }
         return false;
     }
-
+    
     protected void _buffer(int index, BufferedValue v)
     {
         _lastBuffered = Math.max(_lastBuffered, index);

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -982,7 +982,7 @@ public class CsvEncoder
                         // 31-Dec-2014, tatu: Comment lines start with # so quote if starts with #
                         || (c == '#' && i == 0)) {
                     return true;
-                }
+                }    
             } else if (c == esc) {
                 return true;
             }

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -982,7 +982,7 @@ public class CsvEncoder
                         // 31-Dec-2014, tatu: Comment lines start with # so quote if starts with #
                         || (c == '#' && i == 0)) {
                     return true;
-                }    
+                }
             } else if (c == esc) {
                 return true;
             }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
@@ -74,7 +74,7 @@ public class TestGenerator extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         CsvSchema schema = mapper.schemaFor(FiveMinuteUser.class).withHeader();
         FiveMinuteUser user = new FiveMinuteUser("Barbie", "Benton", false, Gender.FEMALE, null);
-        String result = mapper.writer(schema).writeValueAsString(user);
+        String result = mapper.writer(schema).writeValueAsString(user);        
         assertEquals("firstName,lastName,gender,verified,userImage\n"
                 +"Barbie,Benton,FEMALE,false,\n", result);
         

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
@@ -56,7 +56,7 @@ public class TestGenerator extends ModuleTestBase
 
         // from base, default order differs:
         // @JsonPropertyOrder({"firstName", "lastName", "gender" ,"verified", "userImage"})
-
+        
         FiveMinuteUser user = new FiveMinuteUser("Silu", "Seppala", false, Gender.MALE,
                 new byte[] { 1, 2, 3, 4, 5});
         String csv = mapper.writer(schema).writeValueAsString(user);
@@ -77,7 +77,7 @@ public class TestGenerator extends ModuleTestBase
         String result = mapper.writer(schema).writeValueAsString(user);
         assertEquals("firstName,lastName,gender,verified,userImage\n"
                 +"Barbie,Benton,FEMALE,false,\n", result);
-
+        
     }
 
     /**
@@ -90,7 +90,7 @@ public class TestGenerator extends ModuleTestBase
         CsvSchema schema = CsvSchema.builder().setUseHeader(true).build();
         FiveMinuteUser user = new FiveMinuteUser("Barbie", "Benton", false, Gender.FEMALE, null);
         try {
-            mapper.writer(schema).writeValueAsString(user);
+            mapper.writer(schema).writeValueAsString(user);        
             fail("Should fail without columns");
         } catch (JsonMappingException e) {
             verifyException(e, "contains no column names");
@@ -131,7 +131,7 @@ public class TestGenerator extends ModuleTestBase
             .addColumn("id")
             .addColumn("desc")
             .build();
-
+        
         String result = mapper.writer(schema).writeValueAsString(new IdDesc("id", "Some \"stuff\""));
         // MUST use doubling for quotes!
         assertEquals("id,\"Some \"\"stuff\"\"\"\n", result);
@@ -148,7 +148,7 @@ public class TestGenerator extends ModuleTestBase
 
         String base = "Longer sequence with bunch of words to test quoting with needs to be at least one line "
                 +"long to allow for appropriate indexes and boundary crossing conditions as well";
-
+        
         StringBuilder sb = new StringBuilder();
         do {
             for (String word : base.split("\\s")) {
@@ -316,7 +316,7 @@ public class TestGenerator extends ModuleTestBase
         ObjectWriter writer = mapper.writer(schema);
         String csv = writer.writeValueAsString(value);
         assertEquals(expectedCsv, csv);
-    }
+    }    
 
     /*
     /**********************************************************************
@@ -333,9 +333,9 @@ public class TestGenerator extends ModuleTestBase
         String result;
         // having virtual root-level array should make no difference:
         if (wrapAsArray) {
-            result = mapper.writer(schema).writeValueAsString(new FiveMinuteUser[] { user });
+            result = mapper.writer(schema).writeValueAsString(new FiveMinuteUser[] { user });        
         } else {
-            result = mapper.writer(schema).writeValueAsString(user);
+            result = mapper.writer(schema).writeValueAsString(user);        
         }
         assertEquals("Veltto,Virtanen,MALE,true,AwE=\n", result);
     }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/TestGenerator.java
@@ -56,7 +56,7 @@ public class TestGenerator extends ModuleTestBase
 
         // from base, default order differs:
         // @JsonPropertyOrder({"firstName", "lastName", "gender" ,"verified", "userImage"})
-        
+
         FiveMinuteUser user = new FiveMinuteUser("Silu", "Seppala", false, Gender.MALE,
                 new byte[] { 1, 2, 3, 4, 5});
         String csv = mapper.writer(schema).writeValueAsString(user);
@@ -74,10 +74,10 @@ public class TestGenerator extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         CsvSchema schema = mapper.schemaFor(FiveMinuteUser.class).withHeader();
         FiveMinuteUser user = new FiveMinuteUser("Barbie", "Benton", false, Gender.FEMALE, null);
-        String result = mapper.writer(schema).writeValueAsString(user);        
+        String result = mapper.writer(schema).writeValueAsString(user);
         assertEquals("firstName,lastName,gender,verified,userImage\n"
                 +"Barbie,Benton,FEMALE,false,\n", result);
-        
+
     }
 
     /**
@@ -90,7 +90,7 @@ public class TestGenerator extends ModuleTestBase
         CsvSchema schema = CsvSchema.builder().setUseHeader(true).build();
         FiveMinuteUser user = new FiveMinuteUser("Barbie", "Benton", false, Gender.FEMALE, null);
         try {
-            mapper.writer(schema).writeValueAsString(user);        
+            mapper.writer(schema).writeValueAsString(user);
             fail("Should fail without columns");
         } catch (JsonMappingException e) {
             verifyException(e, "contains no column names");
@@ -131,7 +131,7 @@ public class TestGenerator extends ModuleTestBase
             .addColumn("id")
             .addColumn("desc")
             .build();
-        
+
         String result = mapper.writer(schema).writeValueAsString(new IdDesc("id", "Some \"stuff\""));
         // MUST use doubling for quotes!
         assertEquals("id,\"Some \"\"stuff\"\"\"\n", result);
@@ -148,7 +148,7 @@ public class TestGenerator extends ModuleTestBase
 
         String base = "Longer sequence with bunch of words to test quoting with needs to be at least one line "
                 +"long to allow for appropriate indexes and boundary crossing conditions as well";
-        
+
         StringBuilder sb = new StringBuilder();
         do {
             for (String word : base.split("\\s")) {
@@ -202,6 +202,21 @@ public class TestGenerator extends ModuleTestBase
                        .without(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS)
                        .writeValueAsString(new Entry("xyz", 2.5));
         assertEquals("xyz,2.5\n", result);
+    }
+
+    public void testForcedQuotingWithQuoteEscapedWithBackslash() throws Exception
+    {
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema schema = CsvSchema.builder()
+                                    .addColumn("id")
+                                    .addColumn("amount")
+                                    .setEscapeChar('\\')
+                                    .build();
+        String result = mapper.writer(schema)
+                .with(CsvGenerator.Feature.ALWAYS_QUOTE_STRINGS)
+                .with(CsvGenerator.Feature.ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR)
+                .writeValueAsString(new Entry("\"abc\"", 1.25));
+        assertEquals("\"\\\"abc\\\"\",1.25\n", result);
     }
 
     public void testForcedQuotingEmptyStrings() throws Exception
@@ -301,7 +316,7 @@ public class TestGenerator extends ModuleTestBase
         ObjectWriter writer = mapper.writer(schema);
         String csv = writer.writeValueAsString(value);
         assertEquals(expectedCsv, csv);
-    }    
+    }
 
     /*
     /**********************************************************************
@@ -318,9 +333,9 @@ public class TestGenerator extends ModuleTestBase
         String result;
         // having virtual root-level array should make no difference:
         if (wrapAsArray) {
-            result = mapper.writer(schema).writeValueAsString(new FiveMinuteUser[] { user });        
+            result = mapper.writer(schema).writeValueAsString(new FiveMinuteUser[] { user });
         } else {
-            result = mapper.writer(schema).writeValueAsString(user);        
+            result = mapper.writer(schema).writeValueAsString(user);
         }
         assertEquals("Veltto,Virtanen,MALE,true,AwE=\n", result);
     }


### PR DESCRIPTION
Not all CSV parsers accept doubled double-quotes `""` as an escape sequence in a quoted String value.
Added a new feature which allows using the configured escape character instead of hard-coding `""`.
It is false by default to preserve existing behaviour.