### PR TITLE
Add feature to support quoted field names in YAML writer.

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -97,7 +97,12 @@ public class YAMLGenerator extends GeneratorBase
          *<p>
          * Default value is `false` for backwards compatibility
          */
-        INDENT_ARRAYS(false)
+        INDENT_ARRAYS(false),
+
+        /**
+         * Whether keys should always be quoted.
+         */
+        ALWAYS_QUOTE_KEYS(false)
         ;
 
         protected final boolean _defaultState;
@@ -391,7 +396,11 @@ public class YAMLGenerator extends GeneratorBase
     private final void _writeFieldName(String name)
         throws IOException
     {
-        _writeScalar(name, "string", STYLE_NAME);
+        Character style = STYLE_NAME;
+        if (Feature.ALWAYS_QUOTE_KEYS.enabledIn(_formatFeatures)) {
+            style = STYLE_QUOTED;
+        }
+        _writeScalar(name, "string", style);
     }
 
     /*

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorFeatureTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorFeatureTest.java
@@ -1,7 +1,9 @@
 package com.fasterxml.jackson.dataformat.yaml.ser;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -53,5 +55,39 @@ public class GeneratorFeatureTest extends ModuleTestBase
         assertEquals("- \"first\"", parts[1].trim());
         assertEquals("- \"second\"", parts[2].trim());
         assertEquals("- \"third\"", parts[3].trim());
+    }
+
+    public void testQuotedKeys() throws Exception
+    {
+        Map<String, String> input = new HashMap<>();
+        input.put("no", "first");
+        input.put("yes", "second");
+
+        String yaml = MAPPER.writeValueAsString(input);
+
+        if (yaml.startsWith("---")) {
+            yaml = yaml.substring(3);
+        }
+
+        yaml = yaml.trim();
+
+        String[] parts = yaml.split("\n");
+        assertEquals(parts.length, 2);
+        assertEquals("no: \"first\"", parts[0].trim());
+        assertEquals("yes: \"second\"", parts[1].trim());
+
+        ObjectWriter w = MAPPER.writer().with(YAMLGenerator.Feature.ALWAYS_QUOTE_KEYS);
+
+        yaml = w.writeValueAsString(input);
+        if (yaml.startsWith("---")) {
+            yaml = yaml.substring(3);
+        }
+
+        yaml = yaml.trim();
+
+        parts = yaml.split("\n");
+        assertEquals(parts.length, 2);
+        assertEquals("\"no\": \"first\"", parts[0].trim());
+        assertEquals("\"yes\": \"second\"", parts[1].trim());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/FasterXML/jackson-dataformats-text/issues/68.

/cc @cowtowncoder 