### PR TITLE
Fix #81 (update snakeyaml version to 1.21)

### DIFF
--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.19</version>
+      <version>1.21</version>
     </dependency>
 
      <!-- and for testing need annotations -->

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.DumperOptions.ScalarStyle;
 import org.yaml.snakeyaml.emitter.Emitter;
 import org.yaml.snakeyaml.events.*;
 import org.yaml.snakeyaml.nodes.Tag;
@@ -173,7 +174,7 @@ public class YAMLGenerator extends GeneratorBase
 
     // Which flow style to use for Base64? Maybe basic quoted?
     // 29-Nov-2017, tatu: Actually SnakeYAML uses block style so:
-    private final static Character STYLE_BASE64 = STYLE_LITERAL;
+    private final static ScalarStyle STYLE_BASE64 = ScalarStyle.createStyle(STYLE_LITERAL);
 
     private final static Character STYLE_PLAIN = null;
 
@@ -428,7 +429,7 @@ public class YAMLGenerator extends GeneratorBase
     {
         _verifyValueWrite("start an array");
         _outputContext = _outputContext.createChildArrayContext();
-        Boolean style = _outputOptions.getDefaultFlowStyle().getStyleBoolean();
+        FlowStyle style = _outputOptions.getDefaultFlowStyle();
         String yamlTag = _typeId;
         boolean implicit = (yamlTag == null);
         String anchor = _objectId;
@@ -456,7 +457,7 @@ public class YAMLGenerator extends GeneratorBase
     {
         _verifyValueWrite("start an object");
         _outputContext = _outputContext.createChildObjectContext();
-        Boolean style = _outputOptions.getDefaultFlowStyle().getStyleBoolean();
+        FlowStyle style = _outputOptions.getDefaultFlowStyle();
         String yamlTag = _typeId;
         boolean implicit = (yamlTag == null);
         String anchor = _objectId;
@@ -799,6 +800,6 @@ public class YAMLGenerator extends GeneratorBase
         // 29-Nov-2017, tatu: Not 100% sure why we don't force explicit tags for
         //    type id, but trying to do so seems to double up tag output...
         return new ScalarEvent(anchor, yamlTag, NO_TAGS, value,
-                null, null, style);
+                null, null, ScalarStyle.createStyle(style));
     }
 }


### PR DESCRIPTION
This is a (minimalistic) fix for the backwards-incompatible refactoring in snakeyaml `1.20`.

Note: if backwards compatibility with pre-`1.20` snakeyaml is strongly desired we could introduce a wrapper with runtime detection of `*Event` constructor signatures. @cowtowncoder?