### PR TITLE
Avoid escaping when writing to a properties object

### DIFF
--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.GeneratorBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
-import com.fasterxml.jackson.dataformat.javaprop.io.JPropEscapes;
 import com.fasterxml.jackson.dataformat.javaprop.io.JPropWriteContext;
 import com.fasterxml.jackson.dataformat.javaprop.util.Markers;
 
@@ -236,12 +235,12 @@ public abstract class JavaPropsGenerator
                 _basePath.append(sep);
             }
         }
-        // Note that escaping needs to be applied now...
+
+        encode(_basePath, name);
         
-        JPropEscapes.appendKey(_basePath, name);
         // NOTE: we do NOT yet write the key; wait until we have value; just append to path
     }
-
+    
     /*
     /**********************************************************
     /* Public API: structural output
@@ -507,5 +506,7 @@ public abstract class JavaPropsGenerator
     protected abstract void _writeRaw(String text) throws IOException;
     protected abstract void _writeRaw(StringBuilder text) throws IOException;
     protected abstract void _writeRaw(char[] text, int offset, int len) throws IOException;
+    protected abstract void encode(StringBuilder sb, String key);
+    
     
 }

--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/impl/PropertiesBackedGenerator.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/impl/PropertiesBackedGenerator.java
@@ -66,6 +66,11 @@ public class PropertiesBackedGenerator extends JavaPropsGenerator
 
     @Override
     protected void _releaseBuffers() { }
+    
+    @Override
+    protected void encode(StringBuilder sb, String key) {
+    	sb.append(key);
+    }
 
     /*
     /**********************************************************

--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/impl/WriterBackedGenerator.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/impl/WriterBackedGenerator.java
@@ -129,6 +129,11 @@ public class WriterBackedGenerator extends JavaPropsGenerator
             _outputTail = 0;
         }
     }
+    
+    @Override
+    protected void encode(StringBuilder sb, String key) {
+    	JPropEscapes.appendKey(_basePath, key);
+    }
 
     /*
     /**********************************************************


### PR DESCRIPTION
Fix for #91