### PR TITLE
Use latest SnakeYAML version 1.23 and get rid of deprecated methods

### DIFF
--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.19</version>
+      <version>1.23</version>
     </dependency>
 
      <!-- and for testing need annotations -->

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -171,20 +171,20 @@ public class YAMLGenerator extends GeneratorBase
     protected DumperOptions _outputOptions;
 
     // for field names, leave out quotes
-    private final static Character STYLE_NAME = null;
+    private final static DumperOptions.ScalarStyle STYLE_NAME = DumperOptions.ScalarStyle.PLAIN;
 
     // numbers, booleans, should use implicit
-    private final static Character STYLE_SCALAR = null;
+    private final static DumperOptions.ScalarStyle STYLE_SCALAR = DumperOptions.ScalarStyle.PLAIN;
     // Strings quoted for fun
-    private final static Character STYLE_QUOTED = Character.valueOf('"');
+    private final static DumperOptions.ScalarStyle STYLE_QUOTED = DumperOptions.ScalarStyle.DOUBLE_QUOTED;
     // Strings in literal (block) style
-    private final static Character STYLE_LITERAL = Character.valueOf('|');
+    private final static DumperOptions.ScalarStyle STYLE_LITERAL = DumperOptions.ScalarStyle.LITERAL;
 
     // Which flow style to use for Base64? Maybe basic quoted?
     // 29-Nov-2017, tatu: Actually SnakeYAML uses block style so:
-    private final static Character STYLE_BASE64 = STYLE_LITERAL;
+    private final static DumperOptions.ScalarStyle STYLE_BASE64 = STYLE_LITERAL;
 
-    private final static Character STYLE_PLAIN = null;
+    private final static DumperOptions.ScalarStyle STYLE_PLAIN = DumperOptions.ScalarStyle.PLAIN;
 
     /*
     /**********************************************************************
@@ -441,7 +441,7 @@ public class YAMLGenerator extends GeneratorBase
     {
         _verifyValueWrite("start an array");
         _outputContext = _outputContext.createChildArrayContext();
-        Boolean style = _outputOptions.getDefaultFlowStyle().getStyleBoolean();
+        FlowStyle style = _outputOptions.getDefaultFlowStyle();
         String yamlTag = _typeId;
         boolean implicit = (yamlTag == null);
         String anchor = _objectId;
@@ -469,7 +469,7 @@ public class YAMLGenerator extends GeneratorBase
     {
         _verifyValueWrite("start an object");
         _outputContext = _outputContext.createChildObjectContext();
-        Boolean style = _outputOptions.getDefaultFlowStyle().getStyleBoolean();
+        FlowStyle style = _outputOptions.getDefaultFlowStyle();
         String yamlTag = _typeId;
         boolean implicit = (yamlTag == null);
         String anchor = _objectId;
@@ -506,7 +506,7 @@ public class YAMLGenerator extends GeneratorBase
             return;
         }
         _verifyValueWrite("write String value");
-        Character style = STYLE_QUOTED;
+        DumperOptions.ScalarStyle style = STYLE_QUOTED;
         if (Feature.MINIMIZE_QUOTES.enabledIn(_formatFeatures) && !isBooleanContent(text)) {
           // If this string could be interpreted as a number, it must be quoted.
             if (Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS.enabledIn(_formatFeatures)
@@ -781,7 +781,7 @@ public class YAMLGenerator extends GeneratorBase
     // ... and sometimes we specifically DO want explicit tag:
     private final static ImplicitTuple EXPLICIT_TAGS = new ImplicitTuple(false, false);
 
-    protected void _writeScalar(String value, String type, Character style) throws IOException
+    protected void _writeScalar(String value, String type, DumperOptions.ScalarStyle style) throws IOException
     {
         _emitter.emit(_scalarEvent(value, style));
     }
@@ -799,7 +799,7 @@ public class YAMLGenerator extends GeneratorBase
                 null, null, STYLE_BASE64));
     }
 
-    protected ScalarEvent _scalarEvent(String value, Character style)
+    protected ScalarEvent _scalarEvent(String value, DumperOptions.ScalarStyle style)
     {
         String yamlTag = _typeId;
         if (yamlTag != null) {


### PR DESCRIPTION
If the commits from 2.10 branch are not merged back to master then this pull request can update SnakeYAML to its latest version 1.23