### PR TITLE
properties: add properties prefix as filter/append

### DIFF
--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
@@ -144,6 +144,9 @@ public abstract class JavaPropsGenerator
                     _basePath.append(indent);
                     _jpropContext = JPropWriteContext.createRootContext(_indentLength);
                 }
+                if (_schema.prefix() != null) {
+                    _basePath.append(_schema.prefix());
+                }
             }
             return;
         }

--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsSchema.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsSchema.java
@@ -139,6 +139,12 @@ public class JavaPropsSchema
      */
     protected String _header = "";
 
+    /**
+     * Optional prefix to strip and append to key names.
+     * Useful when subset of properties need to be processed.
+     */
+    protected String _prefix;
+
     /*
     /**********************************************************************
     /* Construction, factories, mutant factories
@@ -157,6 +163,7 @@ public class JavaPropsSchema
         _keyValueSeparator = base._keyValueSeparator;
         _lineEnding = base._lineEnding;
         _header = base._header;
+        _prefix = base._prefix;
     }
 
     /**
@@ -287,6 +294,15 @@ public class JavaPropsSchema
         return s;
     }
 
+    public JavaPropsSchema withPrefix(String v) {
+        if (_equals(v, _prefix)) {
+            return this;
+        }
+        JavaPropsSchema s = new JavaPropsSchema(this);
+        s._prefix = v;
+        return s;
+    }
+
     /**
      * Mutant factory for constructing schema instance where specified
      * header section (piece of text written out right before actual
@@ -369,6 +385,10 @@ public class JavaPropsSchema
 
     public String pathSeparator() {
         return _pathSeparator;
+    }
+
+    public String prefix() {
+        return _prefix;
     }
 
     public boolean writeIndexUsingMarkers() {

--- a/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/PrefixTest.java
+++ b/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/PrefixTest.java
@@ -1,0 +1,42 @@
+package com.fasterxml.jackson.dataformat.javaprop;
+
+import java.util.Map;
+import java.util.Properties;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class PrefixTest extends ModuleTestBase
+{
+    private final JavaPropsMapper MAPPER = mapperForProps();
+
+    public void testPrefixParsing() throws Exception {
+        final String INPUT = "org.o1.firstName=Bob\n"
+                +"org.o1.lastName=Palmer\n"
+                +"org.o2.firstName=Alice\n"
+                +"org.o2.lastName=Black\n"
+                +"junk=AQIDBA==\n";
+        FiveMinuteUser result1 = _mapFrom(MAPPER.reader(JavaPropsSchema.emptySchema().withPrefix("org.o1")), INPUT, FiveMinuteUser.class, false);
+        assertEquals("Bob", result1.firstName);
+        assertEquals("Palmer", result1.lastName);
+        FiveMinuteUser result2 = _mapFrom(MAPPER.reader(JavaPropsSchema.emptySchema().withPrefix("org.o2")), INPUT, FiveMinuteUser.class, false);
+        assertEquals("Alice", result2.firstName);
+        assertEquals("Black", result2.lastName);
+    }
+
+    public void testPrefixGeneration() throws Exception
+    {
+        FiveMinuteUser input = new FiveMinuteUser("Bob", "Palmer", true, Gender.MALE,
+                new byte[] { 1, 2, 3, 4 });
+        String output = MAPPER.writer(JavaPropsSchema.emptySchema().withPrefix("org.o1")).writeValueAsString(input);
+        assertEquals("org.o1.firstName=Bob\n"
+                +"org.o1.lastName=Palmer\n"
+                +"org.o1.gender=MALE\n"
+                +"org.o1.verified=true\n"
+                +"org.o1.userImage=AQIDBA==\n"
+                ,output);
+        Properties props = MAPPER.writeValueAsProperties(input, JavaPropsSchema.emptySchema().withPrefix("org.o1"));
+        assertEquals(5, props.size());
+        assertEquals("true", props.get("org.o1.verified"));
+        assertEquals("MALE", props.get("org.o1.gender"));
+    }
+}


### PR DESCRIPTION
Properties may contain multiple objects based on prefix, for example:

    a.b.c.name =
    a.b.c.id =
    x.y.z.name =
    x.y.z.color =

To read these formats a prefix should be used as a filter when reading and as
append when generating.

A new optional JavaPropsSchema::prefix() and JavaPropsSchema::withPrefix() are
added to control the behavior.

As each path component is an object, use of ObjectReader::withRootName has a
different meaning so schema property was used.

PR #100