### PR TITLE
REF #180 - updates YAML scalars with indicators quoting style

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -175,7 +175,7 @@ public class YAMLGenerator extends GeneratorBase
      * aliases for booleans, and we better quote such values as keys; although Jackson
      * itself has no problems dealing with them, some other tools do have.
      */
-    // 02-Apr-2019, tatu: Some names will look funny if escaped: let's leave out 
+    // 02-Apr-2019, tatu: Some names will look funny if escaped: let's leave out
     //    single letter case (esp so 'y' won't get escaped)
     private final static Set<String> MUST_QUOTE_NAMES = new HashSet<>(Arrays.asList(
 //            "y", "Y", "n", "N",
@@ -217,7 +217,7 @@ public class YAMLGenerator extends GeneratorBase
     protected DumperOptions _outputOptions;
 
     protected final org.yaml.snakeyaml.DumperOptions.Version _docVersion;
-    
+
     // for field names, leave out quotes
     private final static DumperOptions.ScalarStyle STYLE_UNQUOTED_NAME = DumperOptions.ScalarStyle.PLAIN;
 
@@ -964,7 +964,7 @@ public class YAMLGenerator extends GeneratorBase
             return true;
         }
         return false;
-    }    
+    }
 
     private boolean _valueNeedsQuoting(String name) {
         switch (name.charAt(0)) { // caller ensures no empty String
@@ -990,19 +990,28 @@ public class YAMLGenerator extends GeneratorBase
     /**
      * As per YAML <a href="https://yaml.org/spec/1.2/spec.html#id2788859">Plain Style</a>unquoted
      * strings are restricted to a reduced charset and must be quoted in case they contain
-     * one of the following characters.
+     * one of the following characters or character combinations.
      */
     private static boolean _valueHasQuotableChar(String inputStr) {
         for (int i = 0, end = inputStr.length(); i < end; ++i) {
             switch (inputStr.charAt(i)) {
-            case ':':
-            case '#':
             case '[':
             case ']':
             case '{':
             case '}':
             case ',':
                 return true;
+            case '\t':
+            case ' ':
+                if (i < end - 1 && '#' == inputStr.charAt(i + 1)) {
+                    return true;
+                }
+                break;
+            case ':':
+                if (i < end - 1 && (' ' == inputStr.charAt(i + 1) || '\t' == inputStr.charAt(i + 1))) {
+                    return true;
+                }
+                break;
             default:
             }
         }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
@@ -94,15 +94,50 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
     public void testMinimizeQuotesWithStringsContainingSpecialChars() throws Exception {
         Map<String, String> content;
 
+        String yaml = null;
+
+        /* scenarios with plain scalars */
+
         content = Collections.singletonMap("key", "a:b");
-        String yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+        yaml = MINIM_MAPPER.writeValueAsString(content).trim();
         assertEquals("---\n" +
-                "key: \"a:b\"", yaml);
+                "key: a:b", yaml);
 
         content = Collections.singletonMap("key", "a#b");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();
         assertEquals("---\n" +
-                "key: \"a#b\"", yaml);
+                "key: a#b", yaml);
+
+        content = Collections.singletonMap("key", "a# b");
+        yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+        assertEquals("---\n" +
+                "key: a# b", yaml);
+
+        // plus also some edge cases (wrt "false" etc checking
+        yaml = MINIM_MAPPER.writeValueAsString(Collections.singletonMap("key", "f:off")).trim();
+        assertEquals("---\n" +
+                "key: f:off", yaml);
+
+
+        /* scenarios with single quoted scalars */
+
+        content = Collections.singletonMap("key", "::");
+        yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+        assertEquals("---\n" +
+                "key: '::'", yaml);
+
+        content = Collections.singletonMap("key", "#");
+        yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+        assertEquals("---\n" +
+                "key: '#'", yaml);
+
+        content = Collections.singletonMap("key", "#a");
+        yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+        assertEquals("---\n" +
+                "key: '#a'", yaml);
+
+
+        /* scenarios with double quoted scalars */
 
         content = Collections.singletonMap("key", "a[b");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();
@@ -128,10 +163,6 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
         assertEquals("---\n" +
                 "key: \"a,b\"", yaml);
 
-        // plus also some edge cases (wrt "false" etc checking
-        yaml = MINIM_MAPPER.writeValueAsString(Collections.singletonMap("key", "f:off")).trim();
-        assertEquals("---\n" +
-                "key: \"f:off\"", yaml);
     }
 
     public void testLiteralStringsMultiLine() throws Exception
@@ -182,7 +213,7 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
         String yaml = MINIM_MAPPER.writeValueAsString(Collections.singletonMap("key", "20")).trim();
         assertEquals("---\n" +
                 "key: 20", yaml);
-        
+
         yaml = MINIM_MAPPER.writeValueAsString(Collections.singletonMap("key", "2.0")).trim();
         assertEquals("---\n" +
                 "key: 2.0", yaml);
@@ -213,7 +244,7 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
                 MINIM_MAPPER.writeValueAsString(stringKeyMap).trim());
 
         // And then true Integer keys
-        
+
         final Map<Integer, String> intKeyMap = Collections.singletonMap(
                 Integer.valueOf(42), "answer");
 


### PR DESCRIPTION
#181 and 2 more #180 related commits introduce some improved YAML scalars quoting more compliant to the [YAML Spec](https://yaml.org/spec/1.2/spec.html#id2788859), in the MINIMIZE_QUOTES mode; the updated behavior seems to be at least more strict (in quoting) than necessary, as it introduces quoting for any value containing chars as `#` and `:`.

If I am not mistaken [YAML Spec](https://yaml.org/spec/1.2/spec.html#id2788859) states that such plain style limitation is applied for cases where the character combinations ` #` (`<space_or_tab>+<#>`) and `: ` (`<:>+<space_or_tab>`) are present, not the single chars `#` and `:`.

This PR updates behavior by considering the character combinations and not the single chars.

This has been triggered by an update of Jackson from 2.10.4 to 2.11.0 which caused YAML serialization test failures due to the difference in quoting, e.g. in case of scalar representing URIs, JSON references, date or datetime.

I understand that this is probably not a major issue, and e.g. code or tests can be adjusted in dependent projects and downstream, but I believe the affected scenarios are quite common and it would make sense to keep quotes at a minimum when `minimize` is on.

Not sure if the target branch `2.11` is the correct one, was wondering if this could make it for 2.11.1 patch release in case.
