### PR TITLE
Fix #146: Underscores in numbers

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -743,12 +743,12 @@ public class YAMLParser extends ParserBase
     {
         // Int or float?
         if (_currToken == JsonToken.VALUE_NUMBER_INT) {
-            int len = _textValue.length();
+            int len = _cleanedTextValue.length();
             if (_numberNegative) {
                 len--;
             }
             if (len <= 9) { // definitely fits in int
-                _numberInt = Integer.parseInt(_textValue);
+                _numberInt = Integer.parseInt(_cleanedTextValue);
                 _numTypesValid = NR_INT;
                 return;
             }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/deser/StreamingParseTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/deser/StreamingParseTest.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.dataformat.yaml.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
@@ -299,6 +300,15 @@ public class StreamingParseTest extends ModuleTestBase
         p.close();
     }
 
+    public void testYamlLongWithUnderscores() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        LongHolder longHolder = mapper.readValue("v: 1_000_000", LongHolder.class);
+        assertNotNull(longHolder);
+        assertEquals(LongHolder.class, longHolder.getClass());
+        assertEquals(Long.valueOf(1000000), longHolder.getV());
+    }
+
     // [cbor#4]: accidental recognition as double, with multiple dots
     public void testDoubleParsing() throws Exception
     {
@@ -570,5 +580,20 @@ public class StreamingParseTest extends ModuleTestBase
           assertToken(JsonToken.END_OBJECT, p.nextToken());
           assertNull(p.nextToken());
           p.close();
+    }
+
+    static class LongHolder
+    {
+        private Long v;
+
+        public Long getV()
+        {
+            return v;
+        }
+
+        public void setV(Long v)
+        {
+            this.v = v;
+        }
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/FasterXML/jackson-dataformats-text/issues/146 for yaml. The test code below from that issue now passes but I'm unsure on where this test should exist.
```
    private static class LongHolder {
        private Long v;

        public Long getV() {
            return v;
        }

        public void setV(Long v) {
            this.v = v;
        }
    }

    private static class IntHolder {
        private Integer v;

        public Integer getV() {
            return v;
        }

        public void setV(Integer v) {
            this.v = v;
        }
    }

    @Test
    public void testYamlUnderscores() throws IOException {
        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
        mapper.readValue("v: 1000000", IntHolder.class); // ok
        mapper.readValue("v: 1_000_000", IntHolder.class); // ok
        mapper.readValue("v: 1000000", LongHolder.class); // ok

        // throws: com.fasterxml.jackson.databind.JsonMappingException: For input string: "1_000_000"
        mapper.readValue("v: 1_000_000", LongHolder.class);
    }
```

For the fix, it looks like the original fix for https://github.com/FasterXML/jackson-dataformats-text/issues/65  [here](https://github.com/FasterXML/jackson-dataformats-text/commit/632ffb2a6b7ace9dc2628988f3885fb6634f0fc0) missed using the `_cleanedTextValue` in the two places in the PR
