### PR TITLE
update gav version

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -23,7 +23,7 @@ To use this extension on Maven-based projects, use following dependency:
 <dependency>
   <groupId>com.fasterxml.jackson.dataformat</groupId>
   <artifactId>jackson-dataformat-yaml</artifactId>
-  <version>2.9.2</version>
+  <version>2.11.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
badge says 2.11.2 is latest on central, README still had 2.9.2