### PR TITLE
quote special boolean characters when writing

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -1,25 +1,21 @@
 package com.fasterxml.jackson.dataformat.yaml;
 
-import java.io.*;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.core.base.GeneratorBase;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.json.JsonWriteContext;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.emitter.Emitter;
 import org.yaml.snakeyaml.events.*;
 import org.yaml.snakeyaml.nodes.Tag;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.core.base.GeneratorBase;
-import com.fasterxml.jackson.core.json.JsonWriteContext;
-import com.fasterxml.jackson.core.io.IOContext;
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.*;
+import java.util.regex.Pattern;
 
 public class YAMLGenerator extends GeneratorBase
 {
@@ -175,10 +171,8 @@ public class YAMLGenerator extends GeneratorBase
      * aliases for booleans, and we better quote such values as keys; although Jackson
      * itself has no problems dealing with them, some other tools do have.
      */
-    // 02-Apr-2019, tatu: Some names will look funny if escaped: let's leave out
-    //    single letter case (esp so 'y' won't get escaped)
     private final static Set<String> MUST_QUOTE_NAMES = new HashSet<>(Arrays.asList(
-//            "y", "Y", "n", "N",
+            "y", "Y", "n", "N",
             "yes", "Yes", "YES", "no", "No", "NO",
             "true", "True", "TRUE", "false", "False", "FALSE",
             "on", "On", "ON", "off", "Off", "OFF"

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/misc/ReservedNamesTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/misc/ReservedNamesTest.java
@@ -1,9 +1,10 @@
 package com.fasterxml.jackson.dataformat.yaml.misc;
 
-import java.util.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
+
+import java.util.Collections;
+import java.util.Map;
 
 // [dataformats-text#68]: should quote reserved names
 public class ReservedNamesTest extends ModuleTestBase
@@ -16,8 +17,7 @@ public class ReservedNamesTest extends ModuleTestBase
                 "true", "True",
                 "false", "False",
                 "yes", "no",
-                // NOTE: single-letter cases left out on purpose
-//                "y", "Y", "n", "N",
+                "y", "Y", "n", "N",
                 "on", "off",
         }) {
             _testQuotingOfBooleanKeys(value);

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/DatabindWriteTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/DatabindWriteTest.java
@@ -1,5 +1,10 @@
 package com.fasterxml.jackson.dataformat.yaml.ser;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -8,11 +13,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeSet;
-
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
 
 public class DatabindWriteTest extends ModuleTestBase
 {
@@ -58,13 +58,12 @@ public class DatabindWriteTest extends ModuleTestBase
         assertFalse(it.hasNext());
     }
 
-    // Related to [dataformats-test#68], escaping of "reserved" names
-    public void testBasicDatabind2() throws Exception
+    public void testPointSerialization() throws Exception
     {
         String yaml = trimDocMarker(MAPPER.writeValueAsString(new Point(1, 2)));
 
-        // Just verify 'y' will NOT be escaped
-        assertEquals("x: 1\ny: 2", yaml);
+        // 'x' will NOT be escaped, 'y' will be escaped
+        assertEquals("x: 1\n\"y\": 2", yaml);
 
         // Actually let's try reading back, too
         Point p = MAPPER.readValue(yaml, Point.class);


### PR DESCRIPTION
"y" is a boolean (https://yaml.org/type/bool.html) and should be quoted
when written, just like all the other special boolean characters