### PR TITLE
Add FlowStyleResolver to enable custom YAML node style resolution

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
 
+import com.fasterxml.jackson.dataformat.yaml.util.NodeStyleResolver;
 import org.yaml.snakeyaml.DumperOptions;
 
 import com.fasterxml.jackson.core.*;
@@ -66,6 +67,13 @@ public class YAMLFactory extends JsonFactory
      */
     protected final StringQuotingChecker _quotingChecker;
 
+    /**
+     * Helper object used to determine node styles of objects and arrays.
+     *
+     * @since 2.13
+     */
+    protected final NodeStyleResolver _nodeStyleResolver;
+
     /*
     /**********************************************************************
     /* Factory construction, configuration
@@ -94,6 +102,7 @@ public class YAMLFactory extends JsonFactory
         //_version = DumperOptions.Version.V1_1;
         _version = null;
         _quotingChecker = StringQuotingChecker.Default.instance();
+        _nodeStyleResolver = NodeStyleResolver.DEFAULT_INSTANCE;
     }
 
     /**
@@ -106,6 +115,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = src._yamlGeneratorFeatures;
         _version = src._version;
         _quotingChecker = src._quotingChecker;
+        _nodeStyleResolver = src._nodeStyleResolver;
     }
 
     /**
@@ -119,6 +129,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = b.formatGeneratorFeaturesMask();
         _version = b.yamlVersionToWrite();
         _quotingChecker = b.stringQuotingChecker();
+        _nodeStyleResolver = b.nodeStyleResolver();
     }
 
     @Override
@@ -490,7 +501,7 @@ public class YAMLFactory extends JsonFactory
     protected YAMLGenerator _createGenerator(Writer out, IOContext ctxt) throws IOException {
         int feats = _yamlGeneratorFeatures;
         YAMLGenerator gen = new YAMLGenerator(ctxt, _generatorFeatures, feats,
-                _quotingChecker, _objectCodec, out, _version);
+                _quotingChecker, _nodeStyleResolver, _objectCodec, out, _version);
         // any other initializations? No?
         return gen;
     }

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.yaml;
 
+import com.fasterxml.jackson.dataformat.yaml.util.NodeStyleResolver;
 import org.yaml.snakeyaml.DumperOptions;
 
 import com.fasterxml.jackson.core.TSFBuilder;
@@ -34,6 +35,13 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
     protected StringQuotingChecker _quotingChecker;
 
     /**
+     * Helper object used to determine node styles of objects and arrays.
+     *
+     * @since 2.13
+     */
+    protected NodeStyleResolver _nodeStyleResolver;
+
+    /**
      * YAML version for underlying generator to follow, if specified;
      * left as {@code null} for backwards compatibility (which means
      * whatever default settings {@code SnakeYAML} deems best).
@@ -55,6 +63,7 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
         _formatGeneratorFeatures = base._yamlGeneratorFeatures;
         _version = base._version;
         _quotingChecker = base._quotingChecker;
+        _nodeStyleResolver = base._nodeStyleResolver;
     }
 
     // // // Parser features NOT YET defined
@@ -117,6 +126,12 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
         return this;
     }
 
+
+    public YAMLFactoryBuilder nodeStyleResolver(NodeStyleResolver nodeStyleResolver) {
+        _nodeStyleResolver = nodeStyleResolver;
+        return this;
+    }
+
     /**
      * Method for specifying YAML version for generator to use (to produce
      * compliant output); if {@code null} passed, will let {@code SnakeYAML}
@@ -150,6 +165,10 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
             return _quotingChecker;
         }
         return StringQuotingChecker.Default.instance();
+    }
+
+    public NodeStyleResolver nodeStyleResolver() {
+        return _nodeStyleResolver;
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/NodeStyleResolver.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/NodeStyleResolver.java
@@ -1,0 +1,70 @@
+package com.fasterxml.jackson.dataformat.yaml.util;
+
+import org.yaml.snakeyaml.DumperOptions;
+
+/**
+ * Helper interface to customize note styles of object and arrays while exporting YAML objects.
+ */
+public interface NodeStyleResolver {
+
+    /**
+     * Defines which style to apply to a given object or array.
+     *
+     * @see DumperOptions.FlowStyle
+     * @see <a href="http://www.yaml.org/spec/current.html#id2509255">3.2.3.1.
+     * Node Styles (http://yaml.org/spec/1.1)</a>
+     */
+    enum NodeStyle {
+        /**
+         * Block style. i.e.
+         * <pre>
+         *   foo:
+         *   - bar
+         * </pre>
+         * <pre>
+         *   key:
+         *     foo: bar
+         * </pre>
+         */
+        BLOCK,
+        /**
+         * Flow style. i.e.
+         * <pre>
+         *   foo: [bar]
+         * </pre>
+         * <pre>
+         *   key: {foo: bar}
+         * </pre>
+         */
+        FLOW;
+
+        public DumperOptions.FlowStyle getSnakeYamlFlowStyle() {
+            switch (this) {
+                case BLOCK:
+                    return DumperOptions.FlowStyle.BLOCK;
+                case FLOW:
+                    return DumperOptions.FlowStyle.FLOW;
+                default:
+                    throw new IllegalStateException("Unexpected value: " + this);
+            }
+        }
+    }
+
+    NodeStyleResolver DEFAULT_INSTANCE = new NodeStyleResolver() {
+        @Override
+        public NodeStyle resolveStyle(String fieldName) {
+            // default behaviour uses YAMLGenerator._outputOptions.getDefaultFlowStyle() (currently set to BLOCK)
+            return null;
+        }
+    };
+
+    /**
+     * Resolve a node style for given fieldName.
+     *
+     * @param fieldName parent field name of the current object or array. can be null if there is no parent field (i.e.
+     *                  typically root object)
+     * @return the desired {@link NodeStyle} or null to use default value (currently 'BLOCK')
+     */
+    NodeStyle resolveStyle(String fieldName);
+
+}

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/CustomNodeStyleTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/CustomNodeStyleTest.java
@@ -1,0 +1,60 @@
+package com.fasterxml.jackson.dataformat.yaml.ser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.dataformat.yaml.util.NodeStyleResolver;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+public class CustomNodeStyleTest extends ModuleTestBase {
+    static class CustomNodeStyleResolver implements NodeStyleResolver {
+        @Override
+        public NodeStyle resolveStyle(String fieldName) {
+            if (fieldName != null && fieldName.endsWith("_flow"))
+                return NodeStyle.FLOW;
+            else if (fieldName != null && fieldName.endsWith("_block"))
+                return NodeStyle.BLOCK;
+            else
+                return null;
+        }
+    }
+
+    private final ObjectMapper REGULAR_MAPPER = YAMLMapper.builder()
+            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+            .build();
+
+    private final YAMLMapper CUSTOM_MAPPER = YAMLMapper.builder(
+            YAMLFactory.builder()
+                    .nodeStyleResolver(new CustomNodeStyleResolver())
+                    .build())
+            .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+            .build();
+
+    public void testFlowStyles() throws Exception {
+        // list
+        assertEquals("key_flow: [value]",
+                _asYaml(CUSTOM_MAPPER, singletonMap("key_flow", singletonList("value"))));
+        assertEquals("key_block:\n- value",
+                _asYaml(CUSTOM_MAPPER, singletonMap("key_block", singletonList("value"))));
+        assertEquals("key_default:\n- value",
+                _asYaml(REGULAR_MAPPER, singletonMap("key_default", singletonList("value"))));
+
+        // object
+        assertEquals("key_flow: {foo: bar}",
+                _asYaml(CUSTOM_MAPPER, singletonMap("key_flow", singletonMap("foo", "bar"))));
+        assertEquals("key_block:\n  foo: bar",
+                _asYaml(CUSTOM_MAPPER, singletonMap("key_block", singletonMap("foo", "bar"))));
+        assertEquals("key_default:\n  foo: bar",
+                _asYaml(REGULAR_MAPPER, singletonMap("key_default", singletonMap("foo", "bar"))));
+    }
+
+    private String _asYaml(ObjectMapper mapper, Object value) throws Exception {
+        return mapper.writeValueAsString(value).trim();
+    }
+}


### PR DESCRIPTION
This adds a desired mechanism to specify YAML node styles (flow styles in snakeyaml) for individual object and array nodes, via implementing a FlowStyleResolver and checking the field names of given object or array nodes.

References: #185 #133 #43 