### PR TITLE
Special characters shouldn't force double quoting for multi-line strings

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -591,13 +591,13 @@ public class YAMLGenerator extends GeneratorBase
         DumperOptions.ScalarStyle style;
         if (Feature.MINIMIZE_QUOTES.enabledIn(_formatFeatures)) {
             // If one of reserved values ("true", "null"), or, number, preserve quoting:
-            if (_quotingChecker.needToQuoteValue(text)
+            if (text.indexOf('\n') >= 0) {
+                style = STYLE_LITERAL;
+            } else if (_quotingChecker.needToQuoteValue(text)
                 || (Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS.enabledIn(_formatFeatures)
                         && PLAIN_NUMBER_P.matcher(text).matches())
                 ) {
                 style = STYLE_QUOTED;
-            } else if (text.indexOf('\n') >= 0) {
-                style = STYLE_LITERAL;
             } else {
                 style = STYLE_PLAIN;
             }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
@@ -175,6 +175,16 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
                 "key: |-\n  first\n  second\n  third", yaml);
     }
 
+    public void testMinimizeQuotesWithStringsContainingSpecialCharsMultiLine() throws Exception
+    {
+        Map<String, Object> content = new HashMap<String, Object>();
+        content.put("key", "first\nsecond: third");
+        String yaml = MINIM_MAPPER.writeValueAsString(content).trim();
+
+        assertEquals("---\n" +
+                "key: |-\n  first\n  second: third", yaml);
+    }
+
     public void testQuoteNumberStoredAsString() throws Exception
     {
         YAMLFactory f = new YAMLFactory();


### PR DESCRIPTION
the logic added in c427465219bbb7e728ac6378b3ab21fd6dccf151 for #116 to force double-quoting of strings should only apply to single-line strings.  the quoting of multi-line strings look naff, and because they take literal mode, the characters aren't special and the quotes are not necessary.