### PR TITLE
Fix #255 (ensure empty string coercion works for Properties)

### DIFF
--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsMapper.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsMapper.java
@@ -7,9 +7,11 @@ import java.util.Properties;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.Version;
-
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 
 public class JavaPropsMapper extends ObjectMapper
@@ -41,6 +43,15 @@ public class JavaPropsMapper extends ObjectMapper
 
     public JavaPropsMapper(JavaPropsFactory f) {
         super(f);
+
+        // 09-Apr-2021, tatu: [dataformats-text#255]: take empty String to
+        //    mean `null` where applicable; also accept Blank same way
+        enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
+
+        coercionConfigDefaults()
+            .setAcceptBlankAsEmpty(Boolean.TRUE)
+            .setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsEmpty)
+        ;
     }
 
     protected JavaPropsMapper(JavaPropsMapper src) {

--- a/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/ModuleTestBase.java
+++ b/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/ModuleTestBase.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public abstract class ModuleTestBase extends junit.framework.TestCase
 {
     @JsonPropertyOrder({ "topLeft", "bottomRight" })
-    static class Rectangle {
+    protected static class Rectangle {
         public Point topLeft;
         public Point bottomRight;
 
@@ -28,7 +28,7 @@ public abstract class ModuleTestBase extends junit.framework.TestCase
     }
 
     @JsonPropertyOrder({ "x", "y" })
-    static class Point {
+    protected static class Point {
         public int x, y;
         
         protected Point() { }
@@ -38,7 +38,7 @@ public abstract class ModuleTestBase extends junit.framework.TestCase
         }
     }
 
-    static class Points {
+    protected static class Points {
         public List<Point> p;
 
         protected Points() { }

--- a/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/deser/convert/CoerceToBooleanTest.java
+++ b/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/deser/convert/CoerceToBooleanTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.dataformat.javaprop.ModuleTestBase;
 
-// 2020-12-18, tatu: Modified from "jackson-databind" version: XML
+// 2020-12-18, tatu: Modified from "jackson-databind" version: Properties
 //   backend MUST NOT prevent coercion from String since Properties
 //   values are fundamentally textual and only have String values
 public class CoerceToBooleanTest
@@ -32,7 +32,7 @@ public class CoerceToBooleanTest
 
         public void setValue(AtomicBoolean v) { value = v; }
     }
-    
+
     private final ObjectMapper DEFAULT_MAPPER = newPropertiesMapper();
 
     private final ObjectMapper MAPPER_STRING_TO_BOOLEAN_FAIL

--- a/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/deser/convert/DefaultFromEmptyCoercionsTest.java
+++ b/properties/src/test/java/com/fasterxml/jackson/dataformat/javaprop/deser/convert/DefaultFromEmptyCoercionsTest.java
@@ -1,0 +1,175 @@
+package com.fasterxml.jackson.dataformat.javaprop.deser.convert;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.javaprop.ModuleTestBase;
+
+// 09-Apr-2021, tatu: Since Properties format has very loose typing
+//   many coercions are needed and are enabled by default. Let's
+//   verify that "from Empty String" cases work for a full set of
+//   things, as rough equivalent of getting a typed `null`.
+//   Note that this is similar to handling of XML format and probably
+//   many other formats, with notable exceptions of "more typed"
+//   JSON and YAML.
+public class DefaultFromEmptyCoercionsTest extends ModuleTestBase
+{
+    static class SomePrimitives {
+        public int i = 9;
+        public long l = -123L;
+        public double d = -0.5;
+    }
+
+    static class SomeWrappers {
+        public Integer i = Integer.valueOf(3);
+        public Long l = Long.valueOf(7L);
+        public Double d = Double.valueOf(0.25);
+    }
+
+    static class StringBean {
+        public String str = "foobar";
+    }
+
+    static class SomeContainers {
+        public int[] ints;
+        public Collection<String> strings;
+        public List<Point> list;
+        public Map<String,Object> map;
+    }
+
+    private final ObjectMapper DEFAULT_MAPPER = newPropertiesMapper();
+
+    /*
+    /**********************************************************************
+    /* Test methods: JDK types
+    /**********************************************************************
+     */
+    
+    public void testJDKPrimitives() throws Exception
+    {
+        SomePrimitives p;
+        final ObjectReader r = DEFAULT_MAPPER.readerFor(SomePrimitives.class);
+
+        assertNotNull(p = r.readValue("i: 13"));
+        assertEquals(13, p.i);
+        assertNotNull(p = r.readValue("i: "));
+        assertEquals(0, p.i);
+
+        assertNotNull(p = r.readValue("l: -999"));
+        assertEquals(-999L, p.l);
+        assertNotNull(p = r.readValue("l: "));
+        assertEquals(0L, p.l);
+
+        assertNotNull(p = r.readValue("d: 2.25"));
+        assertEquals(2.25, p.d);
+        assertNotNull(p = r.readValue("d: "));
+        assertEquals((double) 0, p.d);
+    }
+
+    public void testJDKWrappers() throws Exception {
+        SomeWrappers w;
+        final ObjectReader r = DEFAULT_MAPPER.readerFor(SomeWrappers.class);
+
+        // 09-Apr-2021, tatu: Defaults to "Empty" for all, including wrappers;
+        //    some users may want to change defaults to coerce into `null` instead
+
+        assertNotNull(w = r.readValue("i: 13"));
+        assertEquals(Integer.valueOf(13), w.i);
+        assertNotNull(w = r.readValue("i: "));
+        assertEquals(Integer.valueOf(0), w.i);
+
+        assertNotNull(w = r.readValue("l: -999"));
+        assertEquals(Long.valueOf(-999L), w.l);
+        assertNotNull(w = r.readValue("l: "));
+        assertEquals(Long.valueOf(0L), w.l);
+
+        assertNotNull(w = r.readValue("d: 2.25"));
+        assertEquals(Double.valueOf(2.25), w.d);
+        assertNotNull(w = r.readValue("d: "));
+        assertEquals(Double.valueOf(0), w.d);
+    }
+
+    public void testJDKStringTypes() throws Exception
+    {
+        StringBean v;
+        final ObjectReader r = DEFAULT_MAPPER.readerFor(StringBean.class);
+
+        // 09-Apr-2021, tatu: I _think_ leading space must be trimmed, whereas trailing
+        //    must not?
+        assertNotNull(v = r.readValue("str:   value "));
+        assertEquals("value ", v.str);
+        assertNotNull(v = r.readValue("str:    \n"));
+        assertEquals("", v.str);
+    }
+
+    public void testJDKContainerTypes() throws Exception {
+        SomeContainers w;
+        final ObjectReader r = DEFAULT_MAPPER.readerFor(SomeContainers.class);
+
+        // Assumption: with nothing to read, should remain `null`; explicit
+        // empty String -> empty
+        assertNotNull(w = r.readValue(""));
+        assertNull(w.ints);
+        assertNull(w.strings);
+        assertNull(w.list);
+        assertNull(w.map);
+
+        assertNotNull(w = r.readValue("ints: "));
+        assertNotNull(w.ints);
+        assertEquals(0, w.ints.length);
+
+        assertNotNull(w = r.readValue("strings: "));
+        assertNotNull(w.strings);
+        assertEquals(0, w.strings.size());
+
+        assertNotNull(w = r.readValue("list: "));
+        assertNotNull(w.list);
+        assertEquals(0, w.list.size());
+
+        assertNotNull(w = r.readValue("map: "));
+        assertNotNull(w.map);
+        assertEquals(0, w.map.size());
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods: user-defined
+    /**********************************************************************
+     */
+
+    public void testPOJOs() throws Exception
+    {
+        final ObjectReader r = DEFAULT_MAPPER.readerFor(Rectangle.class);
+        Rectangle rect;
+
+        // First, empty content, resulting in empty instance
+        rect = r.readValue("\n");
+        assertNotNull(rect);
+        assertNull(rect.topLeft);
+        assertNull(rect.bottomRight);
+
+        // Then empty String for one POJO-property, not the other
+        rect = r.readValue("topLeft: \n");
+        assertNotNull(rect);
+        assertNotNull(rect.topLeft);
+        assertEquals(0, rect.topLeft.x);
+        assertEquals(0, rect.topLeft.y);
+        assertNull(rect.bottomRight);
+
+        rect = r.readValue("bottomRight: \n");
+        assertNotNull(rect);
+        assertNull(rect.topLeft);
+        assertNotNull(rect.bottomRight);
+        assertEquals(0, rect.bottomRight.x);
+        assertEquals(0, rect.bottomRight.y);
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper methods
+    /**********************************************************************
+     */
+}

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,8 @@ Active Maintainers:
 #219: (toml) Add TOML (https://en.wikipedia.org/wiki/TOML) support
  (requested by Suminda S; contributed by Jonas K)
 #240: (csv) Split `CsvMappingException` into `CsvReadException`/`CsvWriteException`
+#255: (properties) Ensure that empty String to null/empty works by default
+  for Properties format
 
 2.12.3 (not yet released)
 


### PR DESCRIPTION
As per title; make Properties backend work similar to XML wrt use of empty String as value (since neither format has native `null`)