### PR TITLE
Fix #258 (no output with byte-backed targets)

### DIFF
--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsFactory.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsFactory.java
@@ -363,7 +363,6 @@ public class JavaPropsFactory extends JsonFactory
     {
         return new WriterBackedGenerator(ctxt, _createWriter(out, null, ctxt),
                 stdFeat, _objectCodec);
-                
     }
 
     /*

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
@@ -241,12 +241,14 @@ public final class TomlFactory extends JsonFactory {
 
     @Override
     protected JsonGenerator _createGenerator(Writer out, IOContext ctxt) throws IOException {
-        return new TomlGenerator(ctxt, _tomlGeneratorFeatures, _objectCodec, out);
+        return new TomlGenerator(ctxt, _generatorFeatures, _tomlGeneratorFeatures,
+                _objectCodec, out);
     }
 
     @Override
     protected JsonGenerator _createUTF8Generator(OutputStream out, IOContext ctxt) throws IOException {
-        return new TomlGenerator(ctxt, _tomlGeneratorFeatures, _objectCodec, new UTF8Writer(ctxt, out));
+        return new TomlGenerator(ctxt, _generatorFeatures, _tomlGeneratorFeatures,
+                _objectCodec, new UTF8Writer(ctxt, out));
     }
 
     /*

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlGenerator.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlGenerator.java
@@ -34,7 +34,6 @@ final class TomlGenerator extends GeneratorBase {
      */
     protected final Writer _out;
 
-
     /*
     /**********************************************************************
     /* Output state
@@ -78,8 +77,9 @@ final class TomlGenerator extends GeneratorBase {
     /**********************************************************************
      */
 
-    public TomlGenerator(IOContext ioCtxt, int stdFeatures, ObjectCodec codec, Writer out) {
-        super(stdFeatures, codec);
+    public TomlGenerator(IOContext ioCtxt, int stdReadFeatures, int tomlReadFeatures,
+            ObjectCodec codec, Writer out) {
+        super(stdReadFeatures, codec);
         _ioContext = ioCtxt;
         _streamWriteContext = TomlWriteContext.createRootContext();
         _out = out;
@@ -377,7 +377,7 @@ final class TomlGenerator extends GeneratorBase {
     @Override
     public void writeEndObject() throws IOException {
         if (!_streamWriteContext.inObject()) {
-            _reportError("Current context not an Ibject but " + _streamWriteContext.typeDesc());
+            _reportError("Current context not an Object but " + _streamWriteContext.typeDesc());
         }
         if (_streamWriteContext._inline) {
             writeRaw('}');


### PR DESCRIPTION
As per title: fix is to pass standard generator features in addition to toml ones; this will correctly pass `flush()` calls as necessary.
(there's potential open question on whether we really should just force flush since we are creating the buffering writer, but for now this suffices).