### PR TITLE
Fix for issue #260 (and unit test) -- resetting of "inline" state for output

### DIFF
--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlWriteContext.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlWriteContext.java
@@ -10,8 +10,7 @@ final class TomlWriteContext extends JsonStreamContext {
 
     /*
     /**********************************************************************
-    /* Simple instance reuse slots; speed up things
-    /* a bit (10-15%) for docs with lots of small arrays/objects
+    /* Simple instance reuse slots; speed up things a bit
     /**********************************************************************
      */
 
@@ -52,7 +51,7 @@ final class TomlWriteContext extends JsonStreamContext {
      */
 
     TomlWriteContext(int type, TomlWriteContext parent,
-                                Object currValue, int basePathLength)
+            Object currValue, int basePathLength)
     {
         super();
         _type = type;
@@ -60,7 +59,7 @@ final class TomlWriteContext extends JsonStreamContext {
         _basePathLength = basePathLength;
         _index = -1;
         _currentValue = currValue;
-        _inline = (parent != null && parent._inline) || type == TYPE_ARRAY;
+        _inline = (type == TYPE_ARRAY) || (parent != null && parent._inline);
     }
 
     private void reset(int type, Object currValue, int basePathLength) {
@@ -69,6 +68,8 @@ final class TomlWriteContext extends JsonStreamContext {
         _currentValue = null;
         _index = -1;
         _currentValue = currValue;
+        // 09-Apr-2021, tatu: [dataformats-text#260]: must reset this flag as well
+        _inline = (type == TYPE_ARRAY) || (_parent != null && _parent._inline);
     }
 
     // // // Factory methods

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ComplexPojoReadWriteTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ComplexPojoReadWriteTest.java
@@ -1,0 +1,178 @@
+package com.fasterxml.jackson.dataformat.toml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Copied from YAML modules "DatabindAdvancedTest"
+public class ComplexPojoReadWriteTest
+{
+    enum Size { SMALL, LARGE; }
+
+    static class MediaItem
+    {
+        private MediaContent _content;
+        private List<Image> _images;
+
+        public MediaItem() { }
+
+        public MediaItem(MediaContent c) {
+            _content = c;
+        }
+
+        public void addPhoto(Image p) {
+            if (_images == null) {
+                _images = new ArrayList<Image>();
+            }
+            _images.add(p);
+        }
+
+        public List<Image> getImages() { return _images; }
+        public void setImages(List<Image> p) { _images = p; }
+
+        public MediaContent getContent() { return _content; }
+        public void setContent(MediaContent c) { _content = c; }
+    }
+
+    static class MediaContent
+    {
+        public enum Player { JAVA, FLASH;  }
+
+        private Player _player;
+        private String _uri;
+        private String _title;
+        private int _width;
+        private int _height;
+        private String _format;
+        private long _duration;
+        private long _size;
+        private int _bitrate;
+        private List<String> _persons;
+        private String _copyright;
+
+        public MediaContent() { }
+
+        protected MediaContent(MediaContent src) {
+            _player = src._player;
+            _uri = src._uri;
+            _title = src._title;
+            _width = src._width;
+            _height = src._height;
+            _format = src._format;
+            _duration = src._duration;
+            _size = src._size;
+            _bitrate = src._bitrate;
+            _persons = src._persons;
+            _copyright = src._copyright;
+        }
+
+        public void addPerson(String p) {
+            if (_persons == null) {
+                _persons = new ArrayList<String>();
+            }
+            _persons.add(p);
+        }
+
+        public Player getPlayer() { return _player; }
+        public String getUri() { return _uri; }
+        public String getTitle() { return _title; }
+        public int getWidth() { return _width; }
+        public int getHeight() { return _height; }
+        public String getFormat() { return _format; }
+        public long getDuration() { return _duration; }
+        public long getSize() { return _size; }
+        public int getBitrate() { return _bitrate; }
+        public List<String> getPersons() { return _persons; }
+        public String getCopyright() { return _copyright; }
+
+        public void setPlayer(Player p) { _player = p; }
+        public void setUri(String u) {  _uri = u; }
+        public void setTitle(String t) {  _title = t; }
+        public void setWidth(int w) {  _width = w; }
+        public void setHeight(int h) {  _height = h; }
+        public void setFormat(String f) {  _format = f;  }
+        public void setDuration(long d) {  _duration = d; }
+        public void setSize(long s) {  _size = s; }
+        public void setBitrate(int b) {  _bitrate = b; }
+        public void setPersons(List<String> p) {  _persons = p; }
+        public void setCopyright(String c) {  _copyright = c; }
+    }
+
+    static class Image
+    {
+        private String _uri;
+        private String _title;
+        private int _width;
+        private int _height;
+        private Size _size;
+
+        public Image() {}
+        public Image(String uri, String title, int w, int h, Size s)
+        {
+          _uri = uri;
+          _title = title;
+          _width = w;
+          _height = h;
+          _size = s;
+        }
+
+        public String getUri() { return _uri; }
+        public String getTitle() { return _title; }
+        public int getWidth() { return _width; }
+        public int getHeight() { return _height; }
+        public Size getSize() { return _size; }
+
+        public void setUri(String u) { _uri = u; }
+        public void setTitle(String t) { _title = t; }
+        public void setWidth(int w) { _width = w; }
+        public void setHeight(int h) { _height = h; }
+        public void setSize(Size s) { _size = s; }
+    }
+
+    /*
+    /**********************************************************************
+    /* Test methods
+    /**********************************************************************
+     */
+
+    // For [dataformats-text#260]: resetting (or lack thereof) of "inlined" flag
+    @Test
+    public void testReadWriteComplexPojo() throws Exception
+    {
+        ObjectMapper mapper = new TomlMapper();
+
+        MediaItem input = new MediaItem();
+        MediaContent content = new MediaContent();
+        content.setTitle("Databind test");
+        content.addPerson("William");
+        content.addPerson("Robert");
+        content.setFormat("jpeg");
+        content.setWidth(900);
+        content.setHeight(120);
+        content.setBitrate(256000);
+        content.setDuration(3600 * 1000L);
+        content.setCopyright("none");
+        content.setPlayer(MediaContent.Player.FLASH);
+        content.setUri("http://whatever.biz");
+        input.setContent(content);
+        input.addPhoto(new Image("http://a.com", "title1", 200, 100, Size.LARGE));
+        input.addPhoto(new Image("http://b.org", "title2", 640, 480, Size.SMALL));
+
+        final String toml = mapper.writeValueAsString(input);
+
+        MediaItem result = mapper.readValue(toml, MediaItem.class);
+        assertNotNull(result);
+        assertNotNull(result.getContent());
+        assertEquals(900, result.getContent().getWidth());
+        assertEquals(120, result.getContent().getHeight());
+        assertNotNull(result.getImages());
+        assertEquals(2, result.getImages().size());
+        assertEquals(Size.SMALL, result.getImages().get(1).getSize());
+    }
+}

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/POJOReadWriteTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/POJOReadWriteTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.junit.Test;
@@ -72,6 +74,18 @@ public class POJOReadWriteTest
 
         public PointWrapper(Point p) { point = p; }
         protected PointWrapper() { }
+    }
+
+    @JsonPropertyOrder({ "ids", "points" })
+    protected static class PointListBean {
+        public List<String> ids;
+        public List<Point> points;
+
+        protected PointListBean() { }
+        protected PointListBean(List<String> ids, List<Point> points) {
+            this.ids = ids;
+            this.points = points;
+        }
     }
 
     public enum Gender { MALE, FEMALE };
@@ -201,5 +215,22 @@ public class POJOReadWriteTest
         assertNotNull(result.bottomRight);
 
         assertEquals(input, result);
+    }
+
+    // Check to see if Objects in Arrays work wrt generation or not
+    @Test
+    public void testPOJOListBean() throws Exception
+    {
+        final PointListBean input = new PointListBean(
+                Arrays.asList("a", "b"),
+                Arrays.asList(new Point(1, 2),
+                        new Point(3, 4))
+        );
+
+        final String toml = MAPPER.writeValueAsString(input);
+        PointListBean result = MAPPER.readerFor(PointListBean.class)
+                .readValue(toml);
+        assertNotNull(result.points);
+        assertEquals(input.points, result.points);
     }
 }


### PR DESCRIPTION
As per title, need a bit more complex nested test to show a problem found via initial `jackson-benchmarks` attempts.