### PR TITLE
Use buffer recycler for TOML buffers

### DIFF
--- a/toml/LICENSE
+++ b/toml/LICENSE
@@ -1,5 +1,7 @@
 Jackson is licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
 
+---
+
 The TOML grammar and some parts of the test suite are adapted from the TOML project, which is licensed under the MIT license:
 
 The MIT License
@@ -23,3 +25,41 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+---
+
+The JFlex lexer generator is licensed under a 3-clause BSD-style license:
+
+JFlex - Copying, Warranty & License
+===================================
+
+JFlex is free software, since version 1.5 published under the terms of this
+[3-clause BSD-style license](https://opensource.org/licenses/BSD-3-Clause).
+
+There is absolutely NO WARRANTY for JFlex, its code and its documentation.
+
+
+Copyright (c) Gerwin Klein, Steve Rowe, Régis Décamps, Google LLC.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list of conditions
+    and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice, this list of
+    conditions and the following disclaimer in the documentation and/or other materials provided
+    with the distribution.
+  * Neither the names of the authors nor the names of JFlex contributors may be used to endorse
+    or promote products derived from this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/toml/pom.xml
+++ b/toml/pom.xml
@@ -71,6 +71,7 @@
                 <configuration>
                     <backup>false</backup>
                     <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+                    <skeleton>${project.basedir}/src/main/jflex/skeleton-toml</skeleton>
                 </configuration>
             </plugin>
         </plugins>

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -130,7 +130,7 @@ class Parser {
             TomlToken partToken = peek();
             String part;
             if (partToken == TomlToken.STRING) {
-                part = lexer.stringBuilder.toString();
+                part = lexer.textBuffer.contentsAsString();
             } else if (partToken == TomlToken.UNQUOTED_KEY) {
                 part = lexer.yytext();
             } else {
@@ -171,7 +171,7 @@ class Parser {
         TomlToken firstToken = peek();
         switch (firstToken) {
             case STRING:
-                String text = lexer.stringBuilder.toString();
+                String text = lexer.textBuffer.contentsAsString();
                 pollExpected(TomlToken.STRING, nextState);
                 return factory.textNode(text);
             case TRUE:

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
@@ -308,13 +308,12 @@ public final class TomlFactory extends JsonFactory {
      */
 
     private ObjectNode parse(IOContext ctxt, Reader r0) throws IOException {
-        JacksonTomlParseException.ErrorContext errorContext = new JacksonTomlParseException.ErrorContext(ctxt.getSourceReference(), null);
         if (ctxt.isResourceManaged() || isEnabled(StreamReadFeature.AUTO_CLOSE_SOURCE)) {
             try (Reader r = r0) {
-                return Parser.parse(errorContext, _tomlParserFeatures, r);
+                return Parser.parse(ctxt, _tomlParserFeatures, r);
             }
         } else {
-            return Parser.parse(errorContext, _tomlParserFeatures, r0);
+            return Parser.parse(ctxt, _tomlParserFeatures, r0);
         }
     }
 }

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlWriteFeature.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlWriteFeature.java
@@ -15,6 +15,11 @@ public enum TomlWriteFeature implements FormatFeature {
      */
     FAIL_ON_NULL_WRITE(false);
 
+    /**
+     * Internal option for unit tests: Prohibit allocating internal buffers, except through the buffer recycler
+     */
+    static final int INTERNAL_PROHIBIT_INTERNAL_BUFFER_ALLOCATE = 0x80000000;
+
     final boolean _defaultState;
     final int _mask;
 

--- a/toml/src/main/jflex/com/fasterxml/jackson/dataformat/toml/toml.jflex
+++ b/toml/src/main/jflex/com/fasterxml/jackson/dataformat/toml/toml.jflex
@@ -18,6 +18,7 @@ this.ioContext = ioContext;
 this.errorContext = errorContext;
 yybegin(EXPECT_EXPRESSION);
 this.zzBuffer = ioContext.allocTokenBuffer();
+this.textBuffer = ioContext.constructTextBuffer();
 %init}
 
 %{
@@ -28,7 +29,7 @@ this.zzBuffer = ioContext.allocTokenBuffer();
   private boolean releaseTokenBuffer = true;
 
   private boolean trimmedNewline;
-  StringBuilder stringBuilder = new StringBuilder();
+  final com.fasterxml.jackson.core.util.TextBuffer textBuffer;
 
   private void requestLargerBuffer() throws JacksonTomlParseException {
       if (prohibitInternalBufferAllocate) {
@@ -50,20 +51,22 @@ this.zzBuffer = ioContext.allocTokenBuffer();
           ioContext.releaseTokenBuffer(zzBuffer);
           zzBuffer = null;
       }
+      textBuffer.releaseBuffers();
   }
 
   private void startString() {
-      stringBuilder.setLength(0);
+      // resetWithEmpty does not set _currentSegment, so we need this variant to be able to append further data
+      textBuffer.emptyAndGetCurrentSegment();
       trimmedNewline = false;
   }
 
   private void appendNormalTextToken() {
-      // equivalent to stringBuilder.append(yytext()), without the roundtrip through the String constructor
-      stringBuilder.append(zzBuffer, zzStartRead, zzMarkedPos-zzStartRead);
+      // equivalent to append(yytext()), without the roundtrip through the String constructor
+      textBuffer.append(zzBuffer, zzStartRead, zzMarkedPos-zzStartRead);
   }
 
   private void appendNewlineWithPossibleTrim() {
-      if (!trimmedNewline && stringBuilder.length() == 0) {
+      if (!trimmedNewline && textBuffer.size() == 0) {
           trimmedNewline = true;
       } else {
           // \n or \r\n todo: "TOML parsers should feel free to normalize newline to whatever makes sense for their platform."
@@ -76,7 +79,7 @@ this.zzBuffer = ioContext.allocTokenBuffer();
                    (Character.digit(yycharat(3), 16) << 8) |
                    (Character.digit(yycharat(4), 16) << 4) |
                    Character.digit(yycharat(5), 16);
-      stringBuilder.append((char) value);
+      textBuffer.append((char) value);
   }
 
   private void appendUnicodeEscapeLong() throws java.io.IOException {
@@ -89,7 +92,13 @@ this.zzBuffer = ioContext.allocTokenBuffer();
                  (Character.digit(yycharat(8), 16) << 4) |
                  Character.digit(yycharat(9), 16);
      if (Character.isValidCodePoint(value)) {
-         stringBuilder.appendCodePoint(value);
+         // "Such code points can be represented using a single char."
+         if (value <= Character.MAX_VALUE) {
+             textBuffer.append((char) value);
+         } else {
+             textBuffer.append(Character.highSurrogate(value));
+             textBuffer.append(Character.lowSurrogate(value));
+         }
      } else {
          throw errorContext.atPosition(this).generic("Invalid code point " + Integer.toHexString(value));
      }
@@ -370,14 +379,15 @@ HexDig = [0-9A-Fa-f]
     {MlBasicStringDelim} {return TomlToken.STRING;}
     {NewLine} { appendNewlineWithPossibleTrim(); }
     // mlb-quotes: inline
-    \" { stringBuilder.append('"'); }
+    \" { textBuffer.append('"'); }
     // mlb-quotes: at the end
     \" {MlBasicStringDelim} {
-          stringBuilder.append('"');
+          textBuffer.append('"');
           return TomlToken.STRING;
       }
     \"\" {MlBasicStringDelim} {
-          stringBuilder.append("\"\"");
+          textBuffer.append('"');
+          textBuffer.append('"');
           return TomlToken.STRING;
       }
     // mlb-escaped-nl
@@ -387,13 +397,13 @@ HexDig = [0-9A-Fa-f]
 
 <BASIC_STRING, ML_BASIC_STRING> {
     [^\u0000-\u0008\u000a-\u001f\u007f\\\"]+ { appendNormalTextToken(); }
-    \\\" { stringBuilder.append('"'); }
-    \\\\ { stringBuilder.append('\\'); }
-    \\b { stringBuilder.append('\b'); }
-    \\f { stringBuilder.append('\f'); }
-    \\n { stringBuilder.append('\n'); }
-    \\r { stringBuilder.append('\r'); }
-    \\t { stringBuilder.append('\t'); }
+    \\\" { textBuffer.append('"'); }
+    \\\\ { textBuffer.append('\\'); }
+    \\b { textBuffer.append('\b'); }
+    \\f { textBuffer.append('\f'); }
+    \\n { textBuffer.append('\n'); }
+    \\r { textBuffer.append('\r'); }
+    \\t { textBuffer.append('\t'); }
     {UnicodeEscapeShort} { appendUnicodeEscapeShort(); }
     {UnicodeEscapeLong} { appendUnicodeEscapeLong(); }
     \\ { throw errorContext.atPosition(this).generic("Unknown escape sequence"); }
@@ -413,14 +423,15 @@ HexDig = [0-9A-Fa-f]
     [^\u0000-\u0008\u000a-\u001f\u007f']+ { appendNormalTextToken(); }
     {NewLine} { appendNewlineWithPossibleTrim(); }
     // mll-quotes: inline
-    {Apostrophe} { stringBuilder.append('\''); }
+    {Apostrophe} { textBuffer.append('\''); }
     // mll-quotes: at the end
     {Apostrophe} {MlLiteralStringDelim} {
-          stringBuilder.append('\'');
+          textBuffer.append('\'');
           return TomlToken.STRING;
       }
     {Apostrophe}{Apostrophe} {MlLiteralStringDelim} {
-          stringBuilder.append("''");
+          textBuffer.append('\'');
+          textBuffer.append('\'');
           return TomlToken.STRING;
       }
 }

--- a/toml/src/main/jflex/skeleton-toml
+++ b/toml/src/main/jflex/skeleton-toml
@@ -1,0 +1,342 @@
+
+  /** This character denotes the end of file. */
+  public static final int YYEOF = -1;
+
+  /** Initial size of the lookahead buffer. */
+--- private static final int ZZ_BUFFERSIZE = ...;
+
+  // Lexical states.
+---  lexical states, charmap
+
+  /** Error code for "Unknown internal scanner error". */
+  private static final int ZZ_UNKNOWN_ERROR = 0;
+  /** Error code for "could not match input". */
+  private static final int ZZ_NO_MATCH = 1;
+  /** Error code for "pushback value was too large". */
+  private static final int ZZ_PUSHBACK_2BIG = 2;
+
+  /**
+   * Error messages for {@link #ZZ_UNKNOWN_ERROR}, {@link #ZZ_NO_MATCH}, and
+   * {@link #ZZ_PUSHBACK_2BIG} respectively.
+   */
+  private static final String ZZ_ERROR_MSG[] = {
+    "Unknown internal scanner error",
+    "Error: could not match input",
+    "Error: pushback value was too large"
+  };
+
+--- isFinal list
+  /** Input device. */
+  private java.io.Reader zzReader;
+
+  /** Current state of the DFA. */
+  private int zzState;
+
+  /** Current lexical state. */
+  private int zzLexicalState = YYINITIAL;
+
+  /**
+   * This buffer contains the current text to be matched and is the source of the {@link #yytext()}
+   * string.
+   */
+  private char zzBuffer[]; // JACKSON: remove initializer, moved to .jflex file
+
+  /** Text position at the last accepting state. */
+  private int zzMarkedPos;
+
+  /** Current text position in the buffer. */
+  private int zzCurrentPos;
+
+  /** Marks the beginning of the {@link #yytext()} string in the buffer. */
+  private int zzStartRead;
+
+  /** Marks the last character in the buffer, that has been read from input. */
+  private int zzEndRead;
+
+  /**
+   * Whether the scanner is at the end of file.
+   * @see #yyatEOF
+   */
+  private boolean zzAtEOF;
+
+  /**
+   * The number of occupied positions in {@link #zzBuffer} beyond {@link #zzEndRead}.
+   *
+   * <p>When a lead/high surrogate has been read from the input stream into the final
+   * {@link #zzBuffer} position, this will have a value of 1; otherwise, it will have a value of 0.
+   */
+  private int zzFinalHighSurrogate = 0;
+
+--- user class code
+
+--- constructor declaration
+
+  /**
+   * Refills the input buffer.
+   *
+   * @return {@code false} iff there was new input.
+   * @exception java.io.IOException  if any I/O-Error occurs
+   */
+  private boolean zzRefill() throws java.io.IOException {
+
+    /* first: make room (if you can) */
+    if (zzStartRead > 0) {
+      zzEndRead += zzFinalHighSurrogate;
+      zzFinalHighSurrogate = 0;
+      System.arraycopy(zzBuffer, zzStartRead,
+                       zzBuffer, 0,
+                       zzEndRead - zzStartRead);
+
+      /* translate stored positions */
+      zzEndRead -= zzStartRead;
+      zzCurrentPos -= zzStartRead;
+      zzMarkedPos -= zzStartRead;
+      zzStartRead = 0;
+    }
+
+    /* is the buffer big enough? */
+    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
+      /* if not: blow it up */
+      // JACKSON: replace resize logic, more in .jflex
+      requestLargerBuffer();
+      // JACKSON: the low surrogate is read below
+      zzEndRead += zzFinalHighSurrogate;
+      zzFinalHighSurrogate = 0;
+    }
+
+    /* fill the buffer with new input */
+    int requested = zzBuffer.length - zzEndRead;
+    int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+
+    /* not supposed to occur according to specification of java.io.Reader */
+    if (numRead == 0) {
+      throw new java.io.IOException(
+          "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
+    }
+    if (numRead > 0) {
+      zzEndRead += numRead;
+      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
+          --zzEndRead;
+          zzFinalHighSurrogate = 1;
+        } else {                    // There is room in the buffer for at least one more char
+          int c = zzReader.read();  // Expecting to read a paired low surrogate char
+          if (c == -1) {
+            return true;
+          } else {
+            zzBuffer[zzEndRead++] = (char)c;
+          }
+        }
+      }
+      /* potentially more input available */
+      return false;
+    }
+
+    /* numRead < 0 ==> end of stream */
+    return true;
+  }
+
+
+  /**
+   * Closes the input reader.
+   *
+   * @throws java.io.IOException if the reader could not be closed.
+   */
+  public final void yyclose() throws java.io.IOException {
+    zzAtEOF = true; // indicate end of file
+    zzEndRead = zzStartRead; // invalidate buffer
+
+    if (zzReader != null) {
+      zzReader.close();
+    }
+  }
+
+  // JACKSON: remove yyreset without replacement
+
+  /**
+   * Resets the input position.
+   */
+  private final void yyResetPosition() {
+      zzAtBOL  = true;
+      zzAtEOF  = false;
+      zzCurrentPos = 0;
+      zzMarkedPos = 0;
+      zzStartRead = 0;
+      zzEndRead = 0;
+      zzFinalHighSurrogate = 0;
+      yyline = 0;
+      yycolumn = 0;
+      yychar = 0L;
+  }
+
+
+  /**
+   * Returns whether the scanner has reached the end of the reader it reads from.
+   *
+   * @return whether the scanner has reached EOF.
+   */
+  public final boolean yyatEOF() {
+    return zzAtEOF;
+  }
+
+
+  /**
+   * Returns the current lexical state.
+   *
+   * @return the current lexical state.
+   */
+  public final int yystate() {
+    return zzLexicalState;
+  }
+
+
+  /**
+   * Enters a new lexical state.
+   *
+   * @param newState the new lexical state
+   */
+  public final void yybegin(int newState) {
+    zzLexicalState = newState;
+  }
+
+
+  /**
+   * Returns the text matched by the current regular expression.
+   *
+   * @return the matched text.
+   */
+  public final String yytext() {
+    return new String(zzBuffer, zzStartRead, zzMarkedPos-zzStartRead);
+  }
+
+
+  /**
+   * Returns the character at the given position from the matched text.
+   *
+   * <p>It is equivalent to {@code yytext().charAt(pos)}, but faster.
+   *
+   * @param position the position of the character to fetch. A value from 0 to {@code yylength()-1}.
+   *
+   * @return the character at {@code position}.
+   */
+  public final char yycharat(int position) {
+    return zzBuffer[zzStartRead + position];
+  }
+
+
+  /**
+   * How many characters were matched.
+   *
+   * @return the length of the matched text region.
+   */
+  public final int yylength() {
+    return zzMarkedPos-zzStartRead;
+  }
+
+
+  /**
+   * Reports an error that occurred while scanning.
+   *
+   * <p>In a well-formed scanner (no or only correct usage of {@code yypushback(int)} and a
+   * match-all fallback rule) this method will only be called with things that
+   * "Can't Possibly Happen".
+   *
+   * <p>If this method is called, something is seriously wrong (e.g. a JFlex bug producing a faulty
+   * scanner etc.).
+   *
+   * <p>Usual syntax/scanner level error handling should be done in error fallback rules.
+   *
+   * @param errorCode the code of the error message to display.
+   */
+--- zzScanError declaration
+    String message;
+    try {
+      message = ZZ_ERROR_MSG[errorCode];
+    } catch (ArrayIndexOutOfBoundsException e) {
+      message = ZZ_ERROR_MSG[ZZ_UNKNOWN_ERROR];
+    }
+
+--- throws clause
+  }
+
+
+  /**
+   * Pushes the specified amount of characters back into the input stream.
+   *
+   * <p>They will be read again by then next call of the scanning method.
+   *
+   * @param number the number of characters to be read again. This number must not be greater than
+   *     {@link #yylength()}.
+   */
+--- yypushback decl (contains zzScanError exception)
+    if ( number > yylength() )
+      zzScanError(ZZ_PUSHBACK_2BIG);
+
+    zzMarkedPos -= number;
+  }
+
+
+--- zzDoEOF
+
+
+  /**
+   * Resumes scanning until the next regular expression is matched, the end of input is encountered
+   * or an I/O-Error occurs.
+   *
+   * @return the next token.
+   * @exception java.io.IOException if any I/O-Error occurs.
+   */
+--- yylex declaration
+    int zzInput;
+    int zzAction;
+
+    // cached fields:
+    int zzCurrentPosL;
+    int zzMarkedPosL;
+    int zzEndReadL = zzEndRead;
+    char[] zzBufferL = zzBuffer;
+
+--- local declarations
+
+    while (true) {
+      zzMarkedPosL = zzMarkedPos;
+
+--- start admin (line, char, col count)
+      zzAction = -1;
+
+      zzCurrentPosL = zzCurrentPos = zzStartRead = zzMarkedPosL;
+
+--- start admin (lexstate etc)
+
+      zzForAction: {
+        while (true) {
+
+--- next input, line, col, char count, next transition, isFinal action
+            zzAction = zzState;
+            zzMarkedPosL = zzCurrentPosL;
+--- line count update
+          }
+
+        }
+      }
+
+      // store back cached position
+      zzMarkedPos = zzMarkedPosL;
+--- char count update
+
+      if (zzInput == YYEOF && zzStartRead == zzCurrentPos) {
+        zzAtEOF = true;
+--- eofvalue
+      }
+      else {
+--- actions
+          default:
+--- no match
+        }
+      }
+    }
+  }
+
+--- main
+
+}

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/LongTokenTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/LongTokenTest.java
@@ -1,0 +1,109 @@
+package com.fasterxml.jackson.dataformat.toml;
+
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecyclers;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class LongTokenTest {
+    private static final int SCALE = 10000; // must be bigger than the default buffer size
+
+    @Test
+    public void decimal() throws IOException {
+        StringBuilder toml = new StringBuilder("foo = 0.");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('0');
+        }
+        toml.append('1');
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+        BigDecimal decimal = node.get("foo").decimalValue();
+
+        Assert.assertTrue(decimal.compareTo(BigDecimal.ZERO) > 0);
+        Assert.assertTrue(decimal.compareTo(BigDecimal.ONE) < 0);
+    }
+
+    @Test
+    public void integer() throws IOException {
+        StringBuilder toml = new StringBuilder("foo = 0b1");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('0');
+        }
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+        BigInteger integer = node.get("foo").bigIntegerValue();
+
+        Assert.assertEquals(SCALE + 1, integer.bitLength());
+    }
+
+    @Test
+    public void comment() throws IOException {
+        StringBuilder toml = new StringBuilder("# ");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('a');
+        }
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+
+        Assert.assertTrue(node.isEmpty());
+    }
+
+    @Test
+    public void arrayWhitespace() throws IOException {
+        StringBuilder toml = new StringBuilder("foo = [");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append(' ');
+        }
+        toml.append(']');
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+
+        Assert.assertEquals(0, node.get("foo").size());
+    }
+
+    @Test
+    public void unquotedKey() throws IOException {
+        StringBuilder toml = new StringBuilder("f");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('o');
+        }
+        String expectedKey = toml.toString();
+        toml.append(" = 0");
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+
+        Assert.assertEquals(expectedKey, node.fieldNames().next());
+    }
+
+    @Test
+    public void string() throws IOException {
+        StringBuilder toml = new StringBuilder("foo = '");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('a');
+        }
+        toml.append("'");
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), 0, new StringReader(toml.toString()));
+
+        Assert.assertEquals(SCALE, node.get("foo").textValue().length());
+    }
+
+    @Test
+    public void stringEscapes() throws IOException {
+        StringBuilder toml = new StringBuilder("foo = \"");
+        for (int i = 0; i < SCALE; i++) {
+            toml.append("\\n");
+        }
+        toml.append("\"");
+
+        ObjectNode node = Parser.parse(new IOContext(BufferRecyclers.getBufferRecycler(), toml, false), TomlWriteFeature.INTERNAL_PROHIBIT_INTERNAL_BUFFER_ALLOCATE, new StringReader(toml.toString()));
+
+        Assert.assertEquals(SCALE, node.get("foo").textValue().length());
+    }
+}

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ParserTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ParserTest.java
@@ -1,7 +1,9 @@
 package com.fasterxml.jackson.dataformat.toml;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.util.BufferRecyclers;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -23,21 +25,25 @@ import java.time.OffsetDateTime;
 
 @SuppressWarnings("OctalInteger")
 public class ParserTest {
-    private final ObjectMapper jsonMapper = JsonMapper.builder()
+    private static final ObjectMapper jsonMapper = JsonMapper.builder()
             .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
             .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
             .build();
 
-    private ObjectNode json(@Language("json") String json) throws JsonProcessingException {
+    static ObjectNode json(@Language("json") String json) throws JsonProcessingException {
         return (ObjectNode) jsonMapper.readTree(json);
     }
 
-    private ObjectNode toml(@Language("toml") String toml) throws IOException {
+    static ObjectNode toml(@Language("toml") String toml) throws IOException {
         return toml(0, toml);
     }
 
-    private ObjectNode toml(int opts, @Language("toml") String toml) throws IOException {
-        return Parser.parse(new JacksonTomlParseException.ErrorContext(null, null), opts, new StringReader(toml));
+    static ObjectNode toml(int opts, @Language("toml") String toml) throws IOException {
+        return Parser.parse(
+                new IOContext(BufferRecyclers.getBufferRecycler(), toml, false),
+                opts,
+                new StringReader(toml)
+        );
     }
 
     @SuppressWarnings("deprecation")

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/StringOutputUtilTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/StringOutputUtilTest.java
@@ -50,7 +50,7 @@ public class StringOutputUtilTest {
                 Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
-                Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                Assert.assertEquals(rawString, lexer.textBuffer.contentsAsString());
                 lexer.releaseBuffers();
             }
 
@@ -65,7 +65,7 @@ public class StringOutputUtilTest {
                 Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
-                Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                Assert.assertEquals(rawString, lexer.textBuffer.contentsAsString());
                 lexer.releaseBuffers();
             }
 
@@ -85,7 +85,7 @@ public class StringOutputUtilTest {
                 Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
-                Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                Assert.assertEquals(rawString, lexer.textBuffer.contentsAsString());
                 lexer.releaseBuffers();
             }
         }

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/StringOutputUtilTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/StringOutputUtilTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.dataformat.toml;
 
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecyclers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,7 +18,6 @@ public class StringOutputUtilTest {
 
         // reused for performance
         StringBuilder builder = new StringBuilder();
-        Lexer lexer = new Lexer(null, errorContext);
 
         int nUnquoted = 0;
         int nLiteral = 0;
@@ -32,9 +33,10 @@ public class StringOutputUtilTest {
             if ((cats & StringOutputUtil.UNQUOTED_KEY) != 0) {
                 nUnquoted++;
 
-                lexer.yyreset(new StringReader(rawString));
+                Lexer lexer = new Lexer(new StringReader(rawString), new IOContext(BufferRecyclers.getBufferRecycler(), rawString, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_INLINE_KEY);
                 Assert.assertEquals(TomlToken.UNQUOTED_KEY, lexer.yylex());
+                lexer.releaseBuffers();
             }
 
             if ((cats & StringOutputUtil.LITERAL_STRING) != 0) {
@@ -45,10 +47,11 @@ public class StringOutputUtilTest {
                 builder.appendCodePoint(c);
                 builder.append('\'');
 
-                lexer.yyreset(new StringReader(builder.toString()));
+                Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
                 Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                lexer.releaseBuffers();
             }
 
             if ((cats & StringOutputUtil.BASIC_STRING_NO_ESCAPE) != 0) {
@@ -59,10 +62,11 @@ public class StringOutputUtilTest {
                 builder.appendCodePoint(c);
                 builder.append('"');
 
-                lexer.yyreset(new StringReader(builder.toString()));
+                Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
                 Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                lexer.releaseBuffers();
             }
 
             if ((cats & StringOutputUtil.BASIC_STRING) != 0 && c < 0x10000) {
@@ -78,10 +82,11 @@ public class StringOutputUtilTest {
                 }
                 builder.append('"');
 
-                lexer.yyreset(new StringReader(builder.toString()));
+                Lexer lexer = new Lexer(new StringReader(builder.toString()), new IOContext(BufferRecyclers.getBufferRecycler(), builder, false), errorContext);
                 lexer.yybegin(Lexer.EXPECT_VALUE);
                 Assert.assertEquals(TomlToken.STRING, lexer.yylex());
                 Assert.assertEquals(rawString, lexer.stringBuilder.toString());
+                lexer.releaseBuffers();
             }
         }
 


### PR DESCRIPTION
This PR makes the jflex-generated Lexer use allocTokenBuffer for the main token buffer (ba4f8edd47b42daf913447b50d20ae90b1c77759) and constructTextBuffer for string building (c042f4e5f6943eaad1fba1145ecc31362c039d83).

This is accomplished by altering the default jflex skeleton ( https://github.com/jflex-de/jflex/blob/4edfabcaa7eb06a41f8429a7462eca6dc92d7247/jflex/src/main/resources/jflex/skeleton.default ) to remove the character array allocations, and implementing those using IOContext in the .jflex instead. Needing to copy the whole skeleton isn't ideal, but oh well.

This approach only works if individual jflex tokens are smaller than the default buffer returned by allocTokenBuffer. When there are very long tokens, we fall back on new char[]. We cannot use allocTokenBuffer(minSize), because we need to keep the old buffer available, and there cannot be two token buffers in use at the same time from the same IOContext.

Ideally, we would never need to resize the buffers at all. Some of the potential long tokens (maybe all?) are tested in LongTokenTest.

- long numbers could maybe just throw an exception. For json, jackson writes long numbers to the text buffer as fallback, but any "fallback" behavior that only happens with long inputs is difficult with jflex, because DFAs can't count. It'd require creating a new state that implements this behavior.
- comments and whitespace could be ignored, since we never need to access the content of those tokens. Could be solved with a new state fairly easily, if jflex cooperates.
- strings are already copied to the text buffer, and this logic could be improved. Right now, long sequences of unescaped data are processed as a single token for performance, but maybe there's an alternative here too. The "fallback" behavior problems for numbers apply.

All in all I'm not awfully concerned about this problem. None of these cases are likely to occur for "benign" data; even string and comment data is regularly "flushed" as long as there's a newline somewhere in between. So, the only issue here is that someone could build a malicious TOML file that takes a lot of memory to parse, but even then the attack is not very effective, because at most 4x as much memory is used as there is data (2x for utf-8 -> char array, 2x for the resize factor). There are definitely better attacks, e.g. by creating many json nodes (since we cache the whole tree during parsing).

For this reason, imo, it is not worth addressing this beyond what is already in this PR.