### PR TITLE
getColumnDesc returns unpaired square bracket when columns are empty

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -1456,10 +1456,9 @@ public class CsvSchema
     public String getColumnDesc()
     {
         StringBuilder sb = new StringBuilder(100);
+        sb.append('[');
         for (Column col : _columns) {
-            if (sb.length() == 0) {
-                sb.append('[');
-            } else {
+            if (sb.length() > 1) {
                 sb.append(',');
             }
             sb.append('"');

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -142,6 +142,12 @@ public class CsvSchemaTest extends ModuleTestBase
         _verifyLinks(schema);
     }
 
+    public void testColumnDescForEmptyScheme() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema();
+        assertEquals("[]", schema.getColumnDesc());
+    }
+
     private void _verifyLinks(CsvSchema schema)
     {
         List<Column> all = new ArrayList<Column>();


### PR DESCRIPTION
Returns ']' when columns list is empty - this change ensures the starting '[' is added.