### PR TITLE
fix one flaky test

### DIFF
--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/misc/ObjectIdTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/misc/ObjectIdTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 public class ObjectIdTest extends ModuleTestBase
 {
     @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class, property="@id")
+    @JsonPropertyOrder({ "name", "next"})
     static class Node
     {
         public String name;


### PR DESCRIPTION
fix one flaky tests by using annotations. A ﬂaky test is an analysis of web application code that fails to produce the same result each time the same analysis is run. Flaky tests are detected by nondex (https://github.com/TestingResearchIllinois/NonDex) which is tool developped by the research group led by professor Darko at UIUC.
1. com.fasterxml.jackson.dataformat.yaml.misc.ObjectIdTest#testNativeSerialization