### PR TITLE
remove use of hardcoded double value that is no longer needed

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/NumberInput.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/NumberInput.java
@@ -5,9 +5,12 @@ package com.fasterxml.jackson.dataformat.csv.impl;
 public final class NumberInput
 {
     /**
-     * Textual representation of a double constant that can cause nasty problems
-     * with JDK (see http://www.exploringbinary.com/java-hangs-when-converting-2-2250738585072012e-308).
+     * Formerly used constant for a value that was problematic on certain
+     * pre-1.8 JDKs.
+     *
+     * @deprecated Since 2.14 -- do not use
      */
+    @Deprecated //since v2.14.0
     public final static String NASTY_SMALL_DOUBLE = "2.2250738585072012e-308";
 
     /**
@@ -93,10 +96,6 @@ public final class NumberInput
 
     public final static double parseDouble(String numStr) throws NumberFormatException
     {
-        // [JACKSON-486]: avoid some nasty float representations... but should it be MIN_NORMAL or MIN_VALUE?
-        if (NASTY_SMALL_DOUBLE.equals(numStr)) {
-            return Double.MIN_VALUE;
-        }
         return Double.parseDouble(numStr);
     }
 }


### PR DESCRIPTION
The NumberInput class is copied from jackson-core and this class no longer uses this workaround - because Java 8 is minimum JDK supported.