### PR TITLE
Allow to use long keys in YAML

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -137,6 +137,16 @@ public class YAMLGenerator extends GeneratorBase
          * @since 2.9.6
          */
         USE_PLATFORM_LINE_BREAKS(false),
+
+        /**
+         * Option passed to SnakeYAML to enable usage of key longer that 128 characters.
+         * If disabled, the max key length is set to 128 characters.
+         * <p>
+         * Default value is {@code false}.
+         * 
+         * @since 2.14
+         */
+        USE_LONG_KEYS(false),
         ;
 
         protected final boolean _defaultState;
@@ -309,6 +319,10 @@ public class YAMLGenerator extends GeneratorBase
         // 14-May-2018: [dataformats-text#84] allow use of platform linefeed
         if (Feature.USE_PLATFORM_LINE_BREAKS.enabledIn(_formatFeatures)) {
             opt.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
+        }
+
+        if (Feature.USE_LONG_KEYS.enabledIn(_formatFeatures)) {
+            opt.setMaxSimpleKeyLength(1024);
         }
         return opt;
     }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorFeatureTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorFeatureTest.java
@@ -64,6 +64,21 @@ public class GeneratorFeatureTest extends ModuleTestBase
         assertEquals("- \"third\"", parts[3].trim());
     }
 
+    //@since 2.14
+    public void testLongKeys() throws Exception
+    {
+        final String LONG_KEY = "key_longer_than_128_characters_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        ObjectMapper defaultMapper = YAMLMapper.builder().build();
+        final Object inputValue = Collections.singletonMap(LONG_KEY, "value");
+        assertEquals("---\n? " + LONG_KEY + "\n: \"value\"",
+        _trim(defaultMapper.writeValueAsString(inputValue)));
+        
+        ObjectMapper longKeysMapper = YAMLMapper.builder().enable(YAMLGenerator.Feature.USE_LONG_KEYS).build();
+        assertEquals("---\n" + LONG_KEY + ": \"value\"",
+                _trim(longKeysMapper.writeValueAsString(inputValue)));
+    }
+
     // @since 2.12
     public void testYAMLSpecVersionDefault() throws Exception
     {


### PR DESCRIPTION
Adding a new feature (`USE_LONG_KEYS`) that set `maxSimpleKeyLength` to 1024 (the maximum available length). It is set to false by default to keep the default behaviour of SnakeYAML.

It answer this issue : #244.