### PR TITLE
support overriding the codePointLimit

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
+import org.yaml.snakeyaml.LoaderOptions;
 
 @SuppressWarnings("resource")
 public class YAMLFactory extends JsonFactory
@@ -64,11 +65,18 @@ public class YAMLFactory extends JsonFactory
     protected final StringQuotingChecker _quotingChecker;
 
     /**
-     * The limit on number of codepoints when parsing YAML (default is 3Mb).
+     * Configuration for underlying parser to follow, if specified;
+     * left as {@code null} for backwards compatibility (which means
+     * whatever default settings {@code SnakeYAML} deems best).
+     * <p>
+     *     If you need to support parsing YAML files that are larger than 3Mb,
+     *     it is recommended that you provide a LoaderOptions instance where
+     *     you set the Codepoint Limit to a larger value than its 3Mb default.
+     * </p>
      *
      * @since 2.14
      */
-    protected final int _codePointLimit;
+    protected final LoaderOptions _loaderOptions;
 
     /*
     /**********************************************************************
@@ -98,7 +106,7 @@ public class YAMLFactory extends JsonFactory
         //_version = DumperOptions.Version.V1_1;
         _version = null;
         _quotingChecker = StringQuotingChecker.Default.instance();
-        _codePointLimit = YAMLFactoryBuilder.getDefaultCodepointLimit();
+        _loaderOptions = null;
     }
 
     /**
@@ -111,7 +119,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = src._yamlGeneratorFeatures;
         _version = src._version;
         _quotingChecker = src._quotingChecker;
-        _codePointLimit = src._codePointLimit;
+        _loaderOptions = src._loaderOptions;
     }
 
     /**
@@ -125,7 +133,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = b.formatGeneratorFeaturesMask();
         _version = b.yamlVersionToWrite();
         _quotingChecker = b.stringQuotingChecker();
-        _codePointLimit = b.codePointLimit();
+        _loaderOptions = b.loaderOptions();
     }
 
     @Override
@@ -470,13 +478,13 @@ public class YAMLFactory extends JsonFactory
     @Override
     protected YAMLParser _createParser(InputStream in, IOContext ctxt) throws IOException {
         return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
-                _codePointLimit, _objectCodec, _createReader(in, null, ctxt));
+                _loaderOptions, _objectCodec, _createReader(in, null, ctxt));
     }
 
     @Override
     protected YAMLParser _createParser(Reader r, IOContext ctxt) throws IOException {
         return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
-                _codePointLimit, _objectCodec, r);
+                _loaderOptions, _objectCodec, r);
     }
 
     // since 2.4
@@ -484,13 +492,13 @@ public class YAMLFactory extends JsonFactory
     protected YAMLParser _createParser(char[] data, int offset, int len, IOContext ctxt,
             boolean recyclable) throws IOException {
         return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
-                _codePointLimit, _objectCodec, new CharArrayReader(data, offset, len));
+                _loaderOptions, _objectCodec, new CharArrayReader(data, offset, len));
     }
 
     @Override
     protected YAMLParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
         return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
-                _codePointLimit, _objectCodec, _createReader(data, offset, len, null, ctxt));
+                _loaderOptions, _objectCodec, _createReader(data, offset, len, null, ctxt));
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactory.java
@@ -2,7 +2,6 @@ package com.fasterxml.jackson.dataformat.yaml;
 
 import java.io.*;
 import java.net.URL;
-import java.nio.charset.Charset;
 
 import org.yaml.snakeyaml.DumperOptions;
 
@@ -16,8 +15,6 @@ import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
 public class YAMLFactory extends JsonFactory
 {
 	private static final long serialVersionUID = 1L;
-
-	protected final static Charset UTF8 = Charset.forName("UTF-8");
 
 	/**
      * Name used to identify YAML format.
@@ -66,6 +63,13 @@ public class YAMLFactory extends JsonFactory
      */
     protected final StringQuotingChecker _quotingChecker;
 
+    /**
+     * The limit on number of codepoints when parsing YAML (default is 3Mb).
+     *
+     * @since 2.14
+     */
+    protected final int _codePointLimit;
+
     /*
     /**********************************************************************
     /* Factory construction, configuration
@@ -94,6 +98,7 @@ public class YAMLFactory extends JsonFactory
         //_version = DumperOptions.Version.V1_1;
         _version = null;
         _quotingChecker = StringQuotingChecker.Default.instance();
+        _codePointLimit = YAMLFactoryBuilder.getDefaultCodepointLimit();
     }
 
     /**
@@ -106,6 +111,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = src._yamlGeneratorFeatures;
         _version = src._version;
         _quotingChecker = src._quotingChecker;
+        _codePointLimit = src._codePointLimit;
     }
 
     /**
@@ -119,6 +125,7 @@ public class YAMLFactory extends JsonFactory
         _yamlGeneratorFeatures = b.formatGeneratorFeaturesMask();
         _version = b.yamlVersionToWrite();
         _quotingChecker = b.stringQuotingChecker();
+        _codePointLimit = b.codePointLimit();
     }
 
     @Override
@@ -462,28 +469,28 @@ public class YAMLFactory extends JsonFactory
 
     @Override
     protected YAMLParser _createParser(InputStream in, IOContext ctxt) throws IOException {
-        return new YAMLParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures,
-                _objectCodec, _createReader(in, null, ctxt));
+        return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
+                _codePointLimit, _objectCodec, _createReader(in, null, ctxt));
     }
 
     @Override
     protected YAMLParser _createParser(Reader r, IOContext ctxt) throws IOException {
-        return new YAMLParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures,
-                _objectCodec, r);
+        return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
+                _codePointLimit, _objectCodec, r);
     }
 
     // since 2.4
     @Override
     protected YAMLParser _createParser(char[] data, int offset, int len, IOContext ctxt,
             boolean recyclable) throws IOException {
-        return new YAMLParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures,
-                _objectCodec, new CharArrayReader(data, offset, len));
+        return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
+                _codePointLimit, _objectCodec, new CharArrayReader(data, offset, len));
     }
 
     @Override
     protected YAMLParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
-        return new YAMLParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures,
-                _objectCodec, _createReader(data, offset, len, null, ctxt));
+        return new YAMLParser(ctxt, _parserFeatures, _yamlParserFeatures,
+                _codePointLimit, _objectCodec, _createReader(data, offset, len, null, ctxt));
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -18,7 +18,9 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
     /**********************************************************
      */
 
-//    protected int _formatParserFeatures;
+    //copied from https://bitbucket.org/snakeyaml/snakeyaml/src/26624702fab8e0a1c301d7fad723c048528f75c3/src/main/java/org/yaml/snakeyaml/LoaderOptions.java#lines-26
+    private final static int DEFAULT_CODEPOINT_LIMIT = 3 * 1024 * 1024; // 3 MB
+    private int _codePointLimit = DEFAULT_CODEPOINT_LIMIT;
 
     /**
      * Set of {@link YAMLGenerator.Feature}s enabled, as bitmask.
@@ -39,6 +41,10 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
      * whatever default settings {@code SnakeYAML} deems best).
      */
     protected DumperOptions.Version _version;
+
+    public static int getDefaultCodepointLimit() {
+        return DEFAULT_CODEPOINT_LIMIT;
+    }
 
     /*
     /**********************************************************
@@ -132,6 +138,16 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
         return this;
     }
 
+    /**
+     * @param codePointLimit the limit on number of codepoints when parsing YAML (default is 3Mb)
+     * @return This builder instance, to allow chaining
+     * @since 2.14
+     */
+    public YAMLFactoryBuilder codePointLimit(int codePointLimit) {
+        this._codePointLimit = codePointLimit;
+        return this;
+    }
+
     /*
     /**********************************************************
     /* Accessors
@@ -150,6 +166,10 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
             return _quotingChecker;
         }
         return StringQuotingChecker.Default.instance();
+    }
+
+    public int codePointLimit() {
+        return _codePointLimit;
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -4,6 +4,7 @@ import org.yaml.snakeyaml.DumperOptions;
 
 import com.fasterxml.jackson.core.TSFBuilder;
 import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
+import org.yaml.snakeyaml.LoaderOptions;
 
 /**
  * {@link com.fasterxml.jackson.core.TSFBuilder}
@@ -17,10 +18,6 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
     /* Configuration
     /**********************************************************
      */
-
-    //copied from https://bitbucket.org/snakeyaml/snakeyaml/src/26624702fab8e0a1c301d7fad723c048528f75c3/src/main/java/org/yaml/snakeyaml/LoaderOptions.java#lines-26
-    private final static int DEFAULT_CODEPOINT_LIMIT = 3 * 1024 * 1024; // 3 MB
-    private int _codePointLimit = DEFAULT_CODEPOINT_LIMIT;
 
     /**
      * Set of {@link YAMLGenerator.Feature}s enabled, as bitmask.
@@ -42,9 +39,19 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
      */
     protected DumperOptions.Version _version;
 
-    public static int getDefaultCodepointLimit() {
-        return DEFAULT_CODEPOINT_LIMIT;
-    }
+    /**
+     * Configuration for underlying parser to follow, if specified;
+     * left as {@code null} for backwards compatibility (which means
+     * whatever default settings {@code SnakeYAML} deems best).
+     * <p>
+     *     If you need to support parsing YAML files that are larger than 3Mb,
+     *     it is recommended that you provide a LoaderOptions instance where
+     *     you set the Codepoint Limit to a larger value than its 3Mb default.
+     * </p>
+     *
+     * @since 2.14
+     */
+    protected LoaderOptions _loaderOptions;
 
     /*
     /**********************************************************
@@ -139,12 +146,21 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
     }
 
     /**
-     * @param codePointLimit the limit on number of codepoints when parsing YAML (default is 3Mb)
+     * Configuration for underlying parser to follow, if specified;
+     * left as {@code null} for backwards compatibility (which means
+     * whatever default settings {@code SnakeYAML} deems best).
+     * <p>
+     *     If you need to support parsing YAML files that are larger than 3Mb,
+     *     it is recommended that you provide a LoaderOptions instance where
+     *     you set the Codepoint Limit to a larger value than its 3Mb default.
+     * </p>
+     *
+     * @param loaderOptions the {@code SnakeYAML} configuration to use when parsing YAML
      * @return This builder instance, to allow chaining
      * @since 2.14
      */
-    public YAMLFactoryBuilder codePointLimit(int codePointLimit) {
-        this._codePointLimit = codePointLimit;
+    public YAMLFactoryBuilder loaderOptions(LoaderOptions loaderOptions) {
+        _loaderOptions = loaderOptions;
         return this;
     }
 
@@ -168,8 +184,21 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
         return StringQuotingChecker.Default.instance();
     }
 
-    public int codePointLimit() {
-        return _codePointLimit;
+    /**
+     * Configuration for underlying parser to follow, if specified;
+     * left as {@code null} for backwards compatibility (which means
+     * whatever default settings {@code SnakeYAML} deems best).
+     * <p>
+     *     If you need to support parsing YAML files that are larger than 3Mb,
+     *     it is recommended that you provide a LoaderOptions instance where
+     *     you set the Codepoint Limit to a larger value than its 3Mb default.
+     * </p>
+     *
+     * @return the {@code SnakeYAML} configuration to use when parsing YAML
+     * @since 2.14
+     */
+    public LoaderOptions loaderOptions() {
+        return _loaderOptions;
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -177,20 +177,21 @@ public class YAMLParser extends ParserBase
             int parserFeatures, int formatFeatures,
             ObjectCodec codec, Reader reader)
     {
-        this(ctxt, parserFeatures, formatFeatures, YAMLFactoryBuilder.getDefaultCodepointLimit(),
-                codec, reader);
+        this(ctxt, parserFeatures, formatFeatures, null, codec, reader);
     }
 
     public YAMLParser(IOContext ctxt, int parserFeatures, int formatFeatures,
-                      int codePointLimit, ObjectCodec codec, Reader reader)
+                      LoaderOptions loaderOptions, ObjectCodec codec, Reader reader)
     {
         super(ctxt, parserFeatures);
         _objectCodec = codec;
         _formatFeatures = formatFeatures;
         _reader = reader;
-        LoaderOptions loaderOptions = new LoaderOptions();
-        loaderOptions.setCodePointLimit(codePointLimit);
-        _yamlParser = new ParserImpl(new StreamReader(reader), loaderOptions);
+        if (loaderOptions == null) {
+            _yamlParser = new ParserImpl(new StreamReader(reader));
+        } else {
+            _yamlParser = new ParserImpl(new StreamReader(reader), loaderOptions);
+        }
         _cfgEmptyStringsToNull = Feature.EMPTY_STRING_AS_NULL.enabledIn(formatFeatures);
     }
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.math.BigInteger;
 
 import com.fasterxml.jackson.core.io.NumberInput;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.error.Mark;
 import org.yaml.snakeyaml.events.*;
 import org.yaml.snakeyaml.nodes.NodeId;
@@ -166,16 +167,30 @@ public class YAMLParser extends ParserBase
     /* Life-cycle
     /**********************************************************************
      */
-    
+
+
+    /**
+     * @deprecated since 2.14, use other constructor
+     */
+    @Deprecated
     public YAMLParser(IOContext ctxt, BufferRecycler br,
             int parserFeatures, int formatFeatures,
             ObjectCodec codec, Reader reader)
     {
-        super(ctxt, parserFeatures);    
+        this(ctxt, parserFeatures, formatFeatures, YAMLFactoryBuilder.getDefaultCodepointLimit(),
+                codec, reader);
+    }
+
+    public YAMLParser(IOContext ctxt, int parserFeatures, int formatFeatures,
+                      int codePointLimit, ObjectCodec codec, Reader reader)
+    {
+        super(ctxt, parserFeatures);
         _objectCodec = codec;
         _formatFeatures = formatFeatures;
         _reader = reader;
-        _yamlParser = new ParserImpl(new StreamReader(reader));
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(codePointLimit);
+        _yamlParser = new ParserImpl(new StreamReader(reader), loaderOptions);
         _cfgEmptyStringsToNull = Feature.EMPTY_STRING_AS_NULL.enabledIn(formatFeatures);
     }
 


### PR DESCRIPTION
https://github.com/FasterXML/jackson-dataformats-text/issues/337

Work in progress. Will add tests before merging but would like to open a discussion on the APIs.

Another option is to support setting a snakeyaml LoaderOptions instance on YamlFactoryBuilder, so users would have full control. There are other settings in LoaderOptions that might be useful to support. https://www.javadoc.io/doc/org.yaml/snakeyaml/latest/org/yaml/snakeyaml/LoaderOptions.html