### PR TITLE
Fix TOML parse failure when number token hits buffer edge

### DIFF
--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -242,7 +243,12 @@ class Parser {
             }
         }
 
+        ValueNode node = parseIntFromBuffer(buffer, start, length);
         pollExpected(TomlToken.INTEGER, nextState);
+        return node;
+    }
+
+    private ValueNode parseIntFromBuffer(char[] buffer, int start, int length) throws TomlStreamReadException {
         if (length > 2) {
             char baseChar = buffer[start + 1];
 

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/FuzzTomlReadTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/FuzzTomlReadTest.java
@@ -29,7 +29,7 @@ public class FuzzTomlReadTest
             JsonNode n = TOML_MAPPER.readTree(INPUT);
             Assert.fail("Should not pass, got: "+n);
         } catch (StreamReadException e) {
-            verifyException(e, "Invalid number");
+            verifyException(e, "Premature end of file");
             // NOTE: decoding of token for error message seems wrong, cannot
             // quite verify it for the last line
         }
@@ -73,8 +73,7 @@ public class FuzzTomlReadTest
             TOML_MAPPER.readTree(INPUT);
             Assert.fail("Should not pass");
         } catch (StreamReadException e) {
-            verifyException(e, "Invalid number representation");
-            verifyException(e, "Illegal leading minus sign");
+            verifyException(e, "Premature end of file");
         }
     }
         


### PR DESCRIPTION
When a number token is exactly at the end of the lexer text buffer, the parser would advance the lexer, triggering a buffer refill, before the number is parsed from the buffer. This patch moves the advance operation to come after parsing, which resolves the issue.

Kudos to @wbprime for finding this and reporting it as https://github.com/micronaut-projects/micronaut-toml/issues/93 . Not even the fuzzer managed to hit this – maybe because it does not fail fast, and just returns the wrong output (NumberInput does no input checking)?