### PR TITLE
Fix #369: replace use of deprecated method with non-deprecated one

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -18,6 +18,8 @@ Active Maintainers:
 
 #356: Fix TOML parse failure when number token hits buffer edge
  (fix by Jonas K)
+#370: Replace use of deprecated constructor of SnakeYAML ParserImpl
+ (contributed by Andrey S)
 
 2.14.1 (21-Nov-2022)
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -188,10 +188,9 @@ public class YAMLParser extends ParserBase
         _formatFeatures = formatFeatures;
         _reader = reader;
         if (loaderOptions == null) {
-            _yamlParser = new ParserImpl(new StreamReader(reader));
-        } else {
-            _yamlParser = new ParserImpl(new StreamReader(reader), loaderOptions);
+            loaderOptions = new LoaderOptions();
         }
+        _yamlParser = new ParserImpl(new StreamReader(reader), loaderOptions);
         _cfgEmptyStringsToNull = Feature.EMPTY_STRING_AS_NULL.enabledIn(formatFeatures);
     }
 


### PR DESCRIPTION
As per title, remove a deprecation warning: should not have any compatibility consequences.