### PR TITLE
fix broken yaml tests - implement getNumberValueDeferred

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -992,6 +992,11 @@ public class YAMLParser extends ParserBase
     /* Number accessor overrides
     /**********************************************************************
      */
+
+    @Override
+    public Object getNumberValueDeferred() throws IOException {
+        return getDecimalValue();
+    }
     
     @Override
     protected void _parseNumericValue(int expType) throws IOException


### PR DESCRIPTION
* relates to https://github.com/FasterXML/jackson-databind/pull/3761

With YAMLParser, this version is too eager but makes all the tests pass:

    @Override
    public Object getNumberValueDeferred() throws IOException {
        return getDecimalValue();
    }
YAMLParser inherits the getNumberValueDeferred from ParserBase and that has a relatively complicated implementation that doesn't seem to work well for YAMLParser.

`return getNumberValue();` leads to small rounding issues that affect tests