### PR TITLE
Upgrade to Snakeyaml 2.0 (resolves CVE-2022-1471)

### DIFF
--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
+      <version>2.0</version>
     </dependency>
 
      <!-- and for testing need annotations; but should be available via `jackson-databind` above


### PR DESCRIPTION
CVE fix: https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in

* tests pass alright
* may be a bit risky to put into jackson 2.14 (snakeyaml 2.0 is a major release)