### PR TITLE
remove unnecessary code in YamlParser

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -537,9 +537,6 @@ public class YAMLParser extends ParserBase
                 close();
                 return (_currToken = null);
             }
-            if (evt.is(Event.ID.StreamStart)) { // useless, skip
-                continue;
-            }
         }
     }
 


### PR DESCRIPTION
My IDE shows these lines are being unnecessary. `continue` just skips to the end of the loop and the loop starts again. And these lines are already at the end of the loop. Removing this code might improve performance a little bit.