### PR TITLE
toml: Ensure progress in zzRefill

### DIFF
--- a/toml/pom.xml
+++ b/toml/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>de.jflex</groupId>
                 <artifactId>jflex-maven-plugin</artifactId>
-                <version>1.8.2</version>
+                <version>1.9.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -78,20 +78,15 @@ class Parser {
             final Reader reader
     ) throws IOException {
         final TomlFactory factory = tomlFactory == null ? new TomlFactory() : tomlFactory;
+        Parser parser = new Parser(factory, ioContext,
+                new TomlStreamReadException.ErrorContext(ioContext.contentReference(), null),
+                factory.getFormatParserFeatures(), reader);
         try {
-            Parser parser = new Parser(factory, ioContext,
-                    new TomlStreamReadException.ErrorContext(ioContext.contentReference(), null),
-                    factory.getFormatParserFeatures(), reader);
-            try {
-                final ObjectNode node = parser.parse();
-                assert parser.getNestingDepth() == 0;
-                return node;
-            } finally {
-                parser.lexer.releaseBuffers();
-            }
-        } catch (IndexOutOfBoundsException e) {
-            // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51654
-            throw new IOException("Failed to parse TOML input: uncaught IndexOutOfBoundsException", e);
+            final ObjectNode node = parser.parse();
+            assert parser.getNestingDepth() == 0;
+            return node;
+        } finally {
+            parser.lexer.releaseBuffers();
         }
     }
 

--- a/toml/src/main/jflex/skeleton-toml
+++ b/toml/src/main/jflex/skeleton-toml
@@ -94,46 +94,56 @@
       zzStartRead = 0;
     }
 
-    /* is the buffer big enough? */
-    if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
-      /* if not: blow it up */
-      // JACKSON: replace resize logic, more in .jflex
-      requestLargerBuffer();
-      // JACKSON: the low surrogate is read below
-      zzEndRead += zzFinalHighSurrogate;
-      zzFinalHighSurrogate = 0;
-    }
+    // JACKSON: introduce loop, see comment on 'continue' below
+    while (true) {
 
-    /* fill the buffer with new input */
-    int requested = zzBuffer.length - zzEndRead;
-    int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+      /* is the buffer big enough? */
+      if (zzCurrentPos >= zzBuffer.length - zzFinalHighSurrogate) {
+        /* if not: blow it up */
+        // JACKSON: replace resize logic, more in .jflex
+        requestLargerBuffer();
+        // JACKSON: the low surrogate is read below
+        zzEndRead += zzFinalHighSurrogate;
+        zzFinalHighSurrogate = 0;
+      }
 
-    /* not supposed to occur according to specification of java.io.Reader */
-    if (numRead == 0) {
-      throw new java.io.IOException(
-          "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
-    }
-    if (numRead > 0) {
-      zzEndRead += numRead;
-      if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
-        if (numRead == requested) { // We requested too few chars to encode a full Unicode character
-          --zzEndRead;
-          zzFinalHighSurrogate = 1;
-        } else {                    // There is room in the buffer for at least one more char
-          int c = zzReader.read();  // Expecting to read a paired low surrogate char
-          if (c == -1) {
-            return true;
-          } else {
-            zzBuffer[zzEndRead++] = (char)c;
+      /* fill the buffer with new input */
+      int requested = zzBuffer.length - zzEndRead;
+      int numRead = zzReader.read(zzBuffer, zzEndRead, requested);
+
+      /* not supposed to occur according to specification of java.io.Reader */
+      if (numRead == 0) {
+        throw new java.io.IOException(
+            "Reader returned 0 characters. See JFlex examples/zero-reader for a workaround.");
+      }
+      if (numRead > 0) {
+        zzEndRead += numRead;
+        if (Character.isHighSurrogate(zzBuffer[zzEndRead - 1])) {
+          if (numRead == requested) { // We requested too few chars to encode a full Unicode character
+            --zzEndRead;
+            zzFinalHighSurrogate = 1;
+
+            if (numRead == 1) {
+              // JACKSON: we only read one character, and it was a high surrogate. We need to ensure that if we return
+              //  false, zzEndRead has advanced, so we need to try reading another character.
+              continue;
+            }
+          } else {                    // There is room in the buffer for at least one more char
+            int c = zzReader.read();  // Expecting to read a paired low surrogate char
+            if (c == -1) {
+              return true;
+            } else {
+              zzBuffer[zzEndRead++] = (char)c;
+            }
           }
         }
+        /* potentially more input available */
+        return false;
       }
-      /* potentially more input available */
-      return false;
-    }
 
-    /* numRead < 0 ==> end of stream */
-    return true;
+      /* numRead < 0 ==> end of stream */
+      return true;
+    }
   }
 
 

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/FuzzTomlReadTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/FuzzTomlReadTest.java
@@ -77,7 +77,7 @@ public class FuzzTomlReadTest extends TomlMapperTestBase
                 TOML_MAPPER.readTree(is);
                 Assert.fail("Should not pass");
             } catch (IOException e) {
-                verifyException(e, "Failed to parse TOML input");
+                verifyException(e, "EOF in wrong state");
             }
         }
     }


### PR DESCRIPTION
The IndexOutOfBoundsException is caused by a condition where the buffer is still large enough that it can hold one char, but that char is a high surrogate, so zzRefill returns false (no EOF) but does not increase zzEndRead (the high surrogate does not have a corresponding low surrogate yet).

This change simply repeats the zzRefill code until at least one character is fully available.

See #399 #402