### PR TITLE
fix v2.14.0 release note about snakeyaml

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -54,7 +54,7 @@ Active Maintainers:
  (contributed by Falk H)
 #314: (csv) Add fast floating-point parsing, generation support
  (contributed by @pjfanning)
-#335: (yaml) Update to SnakeYAML 1.33
+#335/#346: (yaml) Update to SnakeYAML 1.33
  (contributed by @pjfanning)
 #337: (yaml) Allow overriding of file size limit for YAMLParser by exposing
   SnakeYAML `LoaderOptions`

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -54,7 +54,7 @@ Active Maintainers:
  (contributed by Falk H)
 #314: (csv) Add fast floating-point parsing, generation support
  (contributed by @pjfanning)
-#335: (yaml) Update to SnakeYAML 1.32
+#335: (yaml) Update to SnakeYAML 1.33
  (contributed by @pjfanning)
 #337: (yaml) Allow overriding of file size limit for YAMLParser by exposing
   SnakeYAML `LoaderOptions`


### PR DESCRIPTION
https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0 indicates that snakeyaml 1.33 is the version in the pom