### PR TITLE
Fix IndexOutOfBoundsException in TOML parser

### DIFF
--- a/toml/src/main/jflex/skeleton-toml
+++ b/toml/src/main/jflex/skeleton-toml
@@ -81,8 +81,11 @@
 
     /* first: make room (if you can) */
     if (zzStartRead > 0) {
-      zzEndRead += zzFinalHighSurrogate;
-      zzFinalHighSurrogate = 0;
+      // JACKSON: check bounds before modifying zzEndRead (jackson-dataformats-text#411)
+      if (zzEndRead < zzBuffer.length - zzFinalHighSurrogate) {
+        zzEndRead += zzFinalHighSurrogate;
+        zzFinalHighSurrogate = 0;
+      }
       System.arraycopy(zzBuffer, zzStartRead,
                        zzBuffer, 0,
                        zzEndRead - zzStartRead);

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/failing/FuzzTomlRead57237Test.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/failing/FuzzTomlRead57237Test.java
@@ -29,7 +29,7 @@ public class FuzzTomlRead57237Test extends TomlMapperTestBase
                 Assert.fail("Should not pass");
             } catch (IOException e) {
                 // Possibly not what we should get; tweak once working
-                verifyException(e, "EOF in wrong state");
+                verifyException(e, "Premature end of file");
             }
         }
     }


### PR DESCRIPTION
Add a bounds check so that the proper error (EOF) is thrown. 

Fixes #411