### PR TITLE
Use `LoaderOptions.allowDuplicateKeys` to enforce duplicate key detection

### DIFF
--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.yaml;
 
+import com.fasterxml.jackson.core.StreamReadFeature;
 import org.yaml.snakeyaml.DumperOptions;
 
 import com.fasterxml.jackson.core.TSFBuilder;
@@ -226,6 +227,11 @@ public class YAMLFactoryBuilder extends TSFBuilder<YAMLFactory, YAMLFactoryBuild
      */
     public YAMLFactoryBuilder loaderOptions(LoaderOptions loaderOptions) {
         _loaderOptions = loaderOptions;
+
+        // If the user wants to block duplicate keys this needs to be set in a different way to work
+        if (!_loaderOptions.isAllowDuplicateKeys()) {
+            enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
+        }
         return this;
     }
 

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/deser/ParserDupHandlingTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/deser/ParserDupHandlingTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 
 public class ParserDupHandlingTest extends ModuleTestBase
 {
@@ -28,6 +29,17 @@ public class ParserDupHandlingTest extends ModuleTestBase
     {
         YAMLFactory f = new YAMLFactory();
         f.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+        ObjectMapper mapper = new ObjectMapper(f);
+        _verifyDupsFail(mapper, YAML_WITH_DUPS, false);
+        _verifyDupsFail(mapper, YAML_WITH_DUPS, true);
+    }
+
+    public void testDupChecksEnabledLoaderOptions() throws Exception
+    {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+        YAMLFactory f = YAMLFactory.builder().loaderOptions(loaderOptions).build();
+
         ObjectMapper mapper = new ObjectMapper(f);
         _verifyDupsFail(mapper, YAML_WITH_DUPS, false);
         _verifyDupsFail(mapper, YAML_WITH_DUPS, true);


### PR DESCRIPTION
If the user sets the allowDuplicateKeys to false in the LoaderOptions they expect the system will fail on a duplicate key.
It does not (see https://github.com/FasterXML/jackson-dataformats-text/issues/413 ) and no errors are given to indicate they should have set it in a different way.

With this simple change it will fail on duplicate keys.