### PR TITLE
Fix #386 Option to add .ignorePropery() to Csv builder

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -567,6 +567,15 @@ public class CsvSchema
         }
 
         /**
+         * Helper method called to remove a column
+         *
+         * @since 2.17.2
+         */
+        public boolean removeColumn(Column column) {
+            return _columns.remove(column);
+        }
+
+        /**
          * Helper method called to drop the last collected column name if
          * it is empty: called if {link CsvParser.Feature#ALLOW_TRAILING_COMMA}
          * enabled to remove the last entry after being added initially.
@@ -1499,6 +1508,21 @@ public class CsvSchema
         }
         sb.append(']');
         return sb.toString();
+    }
+    /**
+     * Method for ignoring fields for CsvBuilder
+     * @param ignoreProperties Array of column names to be ignored by the csv builder
+     * @return A newly built {@link CsvSchema} with the ignored properties
+     */
+    public CsvSchema ignoreProperty(String[] ignoreProperties) {
+        Builder b = rebuild();
+        for(String ignoreProperty : ignoreProperties) {
+            if (this._columnsByName.containsKey(ignoreProperty)) {
+                b.removeColumn(this._columnsByName.get(ignoreProperty));
+                this._columnsByName.remove(ignoreProperty);
+            }
+        }
+        return b.build();
     }
 
     /*

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -1498,14 +1498,15 @@ public class CsvSchema
      * @return A newly built {@link CsvSchema} with the ignored properties
      */
     public CsvSchema ignoreProperty(String[] ignoreProperties) {
-        Builder b = rebuild();
+        Map<String, Column> map = this._columnsByName;
         for(String ignoreProperty : ignoreProperties) {
             if (this._columnsByName.containsKey(ignoreProperty)) {
-                b.removeColumn(this._columnsByName.get(ignoreProperty));
-                this._columnsByName.remove(ignoreProperty);
+                map.remove(ignoreProperty);
             }
         }
-        return b.build();
+        CsvSchema csvSchema = new CsvSchema(this, map.values().toArray(new Column[map.size()]));
+        Builder builder = new Builder(csvSchema);
+        return builder.build();
     }
 
     /*

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -1488,7 +1488,7 @@ public class CsvSchema
      * @param ignoreProperties Array of column names to be ignored by the csv builder
      * @return A newly built {@link CsvSchema} with the ignored properties
      */
-    public CsvSchema ignoreProperty(String[] ignoreProperties) {
+    public CsvSchema ignoreProperties(String... ignoreProperties) {
         Map<String, Column> map = this._columnsByName;
         for(String ignoreProperty : ignoreProperties) {
             if (this._columnsByName.containsKey(ignoreProperty)) {

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -559,15 +559,6 @@ public class CsvSchema
         }
 
         /**
-         * Helper method called to remove a column
-         *
-         * @since 2.17.2
-         */
-        public boolean removeColumn(Column column) {
-            return _columns.remove(column);
-        }
-
-        /**
          * Helper method called to drop the last collected column name if
          * it is empty: called if {link CsvParser.Feature#ALLOW_TRAILING_COMMA}
          * enabled to remove the last entry after being added initially.

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -142,7 +142,7 @@ public class CsvSchemaTest extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         CsvSchema schema = mapper.schemaFor(Mixed.class);
         assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
-        schema = schema.ignoreProperty(new String[]{"a", "d", "z"});
+        schema = schema.ignoreProperties("a", "d", "z");
         assertEquals(a2q("['b','c']"), schema.getColumnDesc());
 
         _verifyLinks(schema);
@@ -152,7 +152,7 @@ public class CsvSchemaTest extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         CsvSchema originalSchema = mapper.schemaFor(Mixed.class);
         assertEquals(a2q("['a','b','c','d']"), originalSchema.getColumnDesc());
-        CsvSchema modifiedSchema = originalSchema.ignoreProperty(new String[]{"a", "d", "z"});
+        CsvSchema modifiedSchema = originalSchema.ignoreProperties("a", "d", "z");
         assertEquals(a2q("['b','c']"), modifiedSchema.getColumnDesc());
         assertEquals(a2q("['a','b','c','d']"), originalSchema.getColumnDesc());
 
@@ -165,7 +165,7 @@ public class CsvSchemaTest extends ModuleTestBase
         CsvMapper mapper = mapperForCsv();
         CsvSchema schema = mapper.schemaFor(Mixed.class);
         assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
-        schema = schema.ignoreProperty(new String[]{"q", "w", "e"});
+        schema = schema.ignoreProperties("q", "w", "e");
         assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
 
         _verifyLinks(schema);

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -148,6 +148,18 @@ public class CsvSchemaTest extends ModuleTestBase
         _verifyLinks(schema);
     }
 
+    public void testIgnorePropertyDoesNotModifyUnderLyingSchema() throws Exception {
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema originalSchema = mapper.schemaFor(Mixed.class);
+        assertEquals(a2q("['a','b','c','d']"), originalSchema.getColumnDesc());
+        CsvSchema modifiedSchema = originalSchema.ignoreProperty(new String[]{"a", "d", "z"});
+        assertEquals(a2q("['b','c']"), modifiedSchema.getColumnDesc());
+        assertEquals(a2q("['a','b','c','d']"), originalSchema.getColumnDesc());
+
+        _verifyLinks(modifiedSchema);
+        _verifyLinks(originalSchema);
+    }
+
     // for [ignore Add .ignoreProperty() to csv builder #386]
     public void testIgnorePropertyPropertyNotPresent() throws Exception {
         CsvMapper mapper = mapperForCsv();

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -132,6 +132,28 @@ public class CsvSchemaTest extends ModuleTestBase
         _verifyLinks(schema);
     }
 
+    // for [ignore Add .ignoreProperty() to csv builder #386]
+    public void testIgnoreProperty() throws Exception {
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema schema = mapper.schemaFor(Mixed.class);
+        assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
+        schema = schema.ignoreProperty(new String[]{"a", "d", "z"});
+        assertEquals(a2q("['b','c']"), schema.getColumnDesc());
+
+        _verifyLinks(schema);
+    }
+
+    // for [ignore Add .ignoreProperty() to csv builder #386]
+    public void testIgnorePropertyPropertyNotPresent() throws Exception {
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema schema = mapper.schemaFor(Mixed.class);
+        assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
+        schema = schema.ignoreProperty(new String[]{"q", "w", "e"});
+        assertEquals(a2q("['a','b','c','d']"), schema.getColumnDesc());
+
+        _verifyLinks(schema);
+    }
+
     // for [dataformat-csv#42]
     public void testReorderWithComparator() throws Exception
     {


### PR DESCRIPTION
Added new method CsvSchema.ignoreProperty() to define the properties that need to be removed for the csv.
Issue: https://github.com/FasterXML/jackson-dataformats-text/issues/386