### PR TITLE
close IOContexts

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -504,17 +504,20 @@ public class CsvGenerator extends GeneratorBase
     @Override
     public void close() throws IOException
     {
-        super.close();
+        if (!isClosed()) {
+            super.close();
 
-        // Let's mark row as closed, if we had any...
-        finishRow();
-        
-        // Write the header if necessary, occurs when no rows written
-        if (_handleFirstLine) {
-            _handleFirstLine();
+            // Let's mark row as closed, if we had any...
+            finishRow();
+
+            // Write the header if necessary, occurs when no rows written
+            if (_handleFirstLine) {
+                _handleFirstLine();
+            }
+            _writer.close(_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET),
+                    isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM));
+            _ioContext.close();
         }
-        _writer.close(_ioContext.isResourceManaged() || isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET),
-                isEnabled(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM));
     }
 
     /*

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -303,6 +303,11 @@ public class CsvParser
      */
     protected final StreamReadConstraints _streamReadConstraints;
 
+    /**
+     * @since 2.16
+     */
+    protected final IOContext _ioContext;
+
     protected int _formatFeatures;
 
     /**
@@ -411,6 +416,7 @@ public class CsvParser
             throw new IllegalArgumentException("Can not pass `null` as `java.io.Reader` to read from");
         }
         _objectCodec = codec;
+        _ioContext = ctxt;
         _streamReadConstraints = ctxt.streamReadConstraints();
         _textBuffer = ctxt.constructReadConstrainedTextBuffer();
         DupDetector dups = JsonParser.Feature.STRICT_DUPLICATE_DETECTION.enabledIn(stdFeatures)
@@ -504,7 +510,10 @@ public class CsvParser
     public boolean isClosed() { return _reader.isClosed(); }
 
     @Override
-    public void close() throws IOException { _reader.close(); }
+    public void close() throws IOException {
+        _ioContext.close();
+        _reader.close();
+    }
 
     /*                                                                                       
     /**********************************************************                              

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -511,8 +511,10 @@ public class CsvParser
 
     @Override
     public void close() throws IOException {
-        _ioContext.close();
-        _reader.close();
+        if (!isClosed()) {
+            _reader.close();
+            _ioContext.close();
+        }
     }
 
     /*                                                                                       

--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsGenerator.java
@@ -222,7 +222,13 @@ public abstract class JavaPropsGenerator extends GeneratorBase
     /**********************************************************
      */
 
-//    public void close() throws IOException
+    @Override
+    public void close() throws IOException {
+        if (!isClosed()) {
+            super.close();
+            _ioContext.close();
+        }
+    }
 
 //    public void flush() throws IOException
 

--- a/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsParser.java
+++ b/properties/src/main/java/com/fasterxml/jackson/dataformat/javaprop/JavaPropsParser.java
@@ -47,6 +47,11 @@ public class JavaPropsParser extends ParserMinimalBase
     protected final StreamReadConstraints _streamReadConstraints;
 
     /**
+     * @since 2.16
+     */
+    protected final IOContext _ioContext;
+
+    /**
      * Although most massaging is done later, caller may be interested in the
      * ultimate source.
      */
@@ -101,6 +106,7 @@ public class JavaPropsParser extends ParserMinimalBase
             ObjectCodec codec, Map<?,?> sourceMap)
     {
         super(parserFeatures);
+        _ioContext = ctxt;
         _streamReadConstraints = ctxt.streamReadConstraints();
         _objectCodec = codec;
         _inputSource = inputSource;
@@ -151,8 +157,11 @@ public class JavaPropsParser extends ParserMinimalBase
 
     @Override
     public void close() throws IOException {
-        _closed = true;
-        _readContext = null;
+        if (!_closed) {
+            _ioContext.close();
+            _closed = true;
+            _readContext = null;
+        }
     }
 
     @Override

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlFactory.java
@@ -270,8 +270,12 @@ public final class TomlFactory extends JsonFactory
 
     @Override
     public JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {
-        ObjectNode node = parse(ctxt, r);
-        return new TreeTraversingParser(node); // don't pass our _objectCodec, this part shouldn't be customized
+        try {
+            ObjectNode node = parse(ctxt, r);
+            return new TreeTraversingParser(node); // don't pass our _objectCodec, this part shouldn't be customized
+        } finally {
+            ctxt.close();
+        }
     }
 
     @Override

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlGenerator.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/TomlGenerator.java
@@ -120,20 +120,23 @@ final class TomlGenerator extends GeneratorBase
 
     @Override
     public void close() throws IOException {
-        super.close();
-        _flushBuffer();
-        _outputTail = 0; // just to ensure we don't think there's anything buffered
+        if (!isClosed()) {
+            super.close();
+            _flushBuffer();
+            _outputTail = 0; // just to ensure we don't think there's anything buffered
 
-        if (_out != null) {
-            if (_ioContext.isResourceManaged() || isEnabled(StreamWriteFeature.AUTO_CLOSE_TARGET)) {
-                _out.close();
-            } else if (isEnabled(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)) {
-                // If we can't close it, we should at least flush
-                _out.flush();
+            if (_out != null) {
+                if (_ioContext.isResourceManaged() || isEnabled(StreamWriteFeature.AUTO_CLOSE_TARGET)) {
+                    _out.close();
+                } else if (isEnabled(StreamWriteFeature.FLUSH_PASSED_TO_STREAM)) {
+                    // If we can't close it, we should at least flush
+                    _out.flush();
+                }
             }
+            _ioContext.close();
+            // Internal buffer(s) generator has can now be released as well
+            _releaseBuffers();
         }
-        // Internal buffer(s) generator has can now be released as well
-        _releaseBuffers();
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -583,6 +583,7 @@ public class YAMLGenerator extends GeneratorBase
                     _writer.flush();
                 }
             }
+            _ioContext.close();
         }
     }
 


### PR DESCRIPTION
needed after https://github.com/FasterXML/jackson-core/pull/1064

If I have time, I can come back and try to add tests that check that buffer recyclers are being recycled.