### PR TITLE
test: use correct test input as stated by testname

### DIFF
--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/SkipEmptyLines15Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/SkipEmptyLines15Test.java
@@ -196,7 +196,7 @@ public class SkipEmptyLines15Test extends ModuleTestBase {
     public void testCsvWithTrailingBlankLineSkipBlankLinesFeatureEnabled() throws Exception {
         String[][] rows = mapperForCsvAsArray()
                 .with(CsvParser.Feature.SKIP_EMPTY_LINES)
-                .readValue(CSV_WITH_FIRST_BLANK_LINE);
+                .readValue(CSV_WITH_TRAILING_BLANK_LINES);
         // blank lines are skipped
         assertArrayEquals(expected(
                 row("1", "xyz"),


### PR DESCRIPTION
Use test input that seems appropriate given test name and neighboring cases