### PR TITLE
Fix issue 454: Wrap unexpected NumberFormatException

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -250,6 +250,8 @@ Arthur Chan (arthurscchan@github)
 * Contributed fix for #445: `YAMLParser` throws unexpected `NullPointerException` in certain
   number parsing cases
  (2.16.1)
+* Contributed fix for #454: (yaml) Unexpected `NumberFormatException` in `YAMLParser`
+ (2.17.0)
 
 Mathieu Lavigne (@mathieu-lavigne)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -19,6 +19,8 @@ Active Maintainers:
 #45: (csv) Allow skipping ending line break
   (`CsvGenerator.Feature.WRITE_LINEFEED_AFTER_LAST_ROW`)
  (proposed by Mathieu L)
+#454: (yaml) Unexpected `NumberFormatException` in `YAMLParser`
+ (fix contributed by Arthur C)
 
 2.16.1 (24-Dec-2023)
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -1083,7 +1083,11 @@ public class YAMLParser extends ParserBase
                 len--;
             }
             if (len <= 9) { // definitely fits in int
-                _numberInt = Integer.parseInt(_cleanedTextValue);
+                try {
+                    _numberInt = Integer.parseInt(_cleanedTextValue);
+                } catch (NumberFormatException e) {
+                    _reportInvalidNumber(_cleanedTextValue, 10, e);
+                }
                 _numTypesValid = NR_INT;
                 return;
             }

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -1083,11 +1083,7 @@ public class YAMLParser extends ParserBase
                 len--;
             }
             if (len <= 9) { // definitely fits in int
-                try {
-                    _numberInt = Integer.parseInt(_cleanedTextValue);
-                } catch (NumberFormatException e) {
-                    _reportInvalidNumber(_cleanedTextValue, 10, e);
-                }
+                _numberInt = _decodeInt(_cleanedTextValue, 10);
                 _numTypesValid = NR_INT;
                 return;
             }
@@ -1168,8 +1164,9 @@ public class YAMLParser extends ParserBase
                 len--;
             }
             if (len <= 9) { // definitely fits in int
+                _numberInt = _decodeInt(_cleanedTextValue, 10);
                 _numTypesValid = NR_INT;
-                return (_numberInt = Integer.parseInt(_cleanedTextValue));
+                return _numberInt;
             }
         }
         _parseNumericValue(NR_INT);

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -1240,7 +1240,7 @@ public class YAMLParser extends ParserBase
             }
         }
         _cleanedTextValue = sb.toString();
-        if (_cleanedTextValue.isEmpty()) {
+        if (_cleanedTextValue.isEmpty() || "-".equals(_cleanedTextValue)) {
             _reportError(String.format("Invalid number ('%s')", str));
         }
         return JsonToken.VALUE_NUMBER_INT;

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
@@ -1,8 +1,9 @@
 package com.fasterxml.jackson.dataformat.yaml.fuzz;
 
-import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
 
 public class FuzzYAMLRead65855Test extends ModuleTestBase
@@ -14,12 +15,13 @@ public class FuzzYAMLRead65855Test extends ModuleTestBase
     {
         String doc = "!!int\n-_";
 
-        try {
-            MAPPER.readTree(doc);
+        try (JsonParser p = MAPPER.createParser(doc)) {
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            p.getIntValue();
             // Ok; don't care about content, just buffer reads
             fail("Should not pass");
         } catch (JacksonException e) {
-            verifyException(e, "Invalid base-10 number");
+            verifyException(e, "Invalid base-10 number ('-')");
         }
     }
 }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
@@ -16,12 +16,11 @@ public class FuzzYAMLRead65855Test extends ModuleTestBase
         String doc = "!!int\n-_";
 
         try (JsonParser p = MAPPER.createParser(doc)) {
+            // Should be triggered by advacing to next token, even without accessing value
             assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-            p.getIntValue();
-            // Ok; don't care about content, just buffer reads
             fail("Should not pass");
         } catch (JacksonException e) {
-            verifyException(e, "Invalid base-10 number ('-')");
+            verifyException(e, "Invalid number ('-_')");
         }
     }
 }

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/fuzz/FuzzYAMLRead65855Test.java
@@ -1,0 +1,25 @@
+package com.fasterxml.jackson.dataformat.yaml.fuzz;
+
+import com.fasterxml.jackson.core.JacksonException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
+
+public class FuzzYAMLRead65855Test extends ModuleTestBase
+{
+    private final ObjectMapper MAPPER = newObjectMapper();
+
+    // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65855
+    public void testMalformedNumber65855() throws Exception
+    {
+        String doc = "!!int\n-_";
+
+        try {
+            MAPPER.readTree(doc);
+            // Ok; don't care about content, just buffer reads
+            fail("Should not pass");
+        } catch (JacksonException e) {
+            verifyException(e, "Invalid base-10 number");
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a suggested fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65855 mentioned in #454 in addition to the fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63274 in #452. The fix suggests a try-catch block to wrap around code that will throw `NumberFormatException` on invalid input.