### PR TITLE
YAML: consider starting `#` and ending `:` as quotable characters

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -258,3 +258,8 @@ Mathieu Lavigne (@mathieu-lavigne)
 * Proposed #45 (and suggested implementation): (csv) Allow skipping ending line break
   (`CsvGenerator.Feature.WRITE_LINEFEED_AFTER_LAST_ROW`)
  (2.17.0)
+
+Michael Edgar (@MikeEdgar)
+
+* Contributed #465: (yaml) YAML: consider starting `#` and ending `:` as quotable characters
+ (2.17.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,9 @@ Active Maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+#465: (yaml) YAML: consider starting `#` and ending `:` as quotable characters
+ (contributed by Michael E)
+
 2.17.0-rc1 (26-Feb-2024)
 
 #45: (csv) Allow skipping ending line break

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
@@ -8,7 +8,7 @@ import java.util.Set;
  * Helper class that defines API used by
  * {@link com.fasterxml.jackson.dataformat.yaml.YAMLGenerator}
  * to check whether property names and String values need to be quoted or not.
- * Also contains default logic implementation; may be sub-classes to provide
+ * Also contains default logic implementation; may be sub-classed to provide
  * alternate implementation.
  *
  * @since 2.12
@@ -142,13 +142,15 @@ public abstract class StringQuotingChecker
                 return true;
             case '#':
                 // [dataformats-text#201]: limit quoting with MINIMIZE_QUOTES
-                if (precededByBlank(inputStr, i)) {
+                // (but not recognized as comment unless starts line or preceded by whitespace)
+                if (precededOnlyByBlank(inputStr, i)) {
                     return true;
                 }
                 break;
             case ':':
                 // [dataformats-text#201]: limit quoting with MINIMIZE_QUOTES
-                if (followedByBlank(inputStr, i)) {
+                // (but recognized as separator only if end-of-line or followed by whitespace)
+                if (followedOnlyByBlank(inputStr, i)) {
                     return true;
                 }
                 break;
@@ -158,21 +160,24 @@ public abstract class StringQuotingChecker
         return false;
     }
 
-    private boolean precededByBlank(String inputStr, int offset) {
+    // @since 2.17
+    protected boolean precededOnlyByBlank(String inputStr, int offset) {
         if (offset == 0) {
             return true;
         }
         return isBlank(inputStr.charAt(offset - 1));
     }
 
-    private boolean followedByBlank(String inputStr, int offset) {
+    // @since 2.17
+    protected boolean followedOnlyByBlank(String inputStr, int offset) {
         if (offset == inputStr.length() - 1) {
             return true;
         }
         return isBlank(inputStr.charAt(offset + 1));
     }
 
-    private boolean isBlank(char value) {
+    // @since 2.17
+    protected boolean isBlank(char value) {
         return (' ' == value || '\t' == value);
     }
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java
@@ -58,10 +58,10 @@ public abstract class StringQuotingChecker
      * Helper method that sub-classes may use to see if given String value is
      * one of:
      *<ul>
-     * <li>YAML 1.1 keyword representing 
+     * <li>YAML 1.1 keyword representing
      *  <a href="https://yaml.org/type/bool.html">boolean</a>
      *  </li>
-     * <li>YAML 1.1 keyword representing 
+     * <li>YAML 1.1 keyword representing
      *  <a href="https://yaml.org/type/null.html">null</a> value
      *   </li>
      * <li>empty String (length 0)
@@ -142,26 +142,38 @@ public abstract class StringQuotingChecker
                 return true;
             case '#':
                 // [dataformats-text#201]: limit quoting with MINIMIZE_QUOTES
-                if (i > 0) {
-                    char d = inputStr.charAt(i-1);
-                    if (' ' == d || '\t' == d) {
-                        return true;
-                    }
+                if (precededByBlank(inputStr, i)) {
+                    return true;
                 }
                 break;
             case ':':
                 // [dataformats-text#201]: limit quoting with MINIMIZE_QUOTES
-                if (i < (end-1)) {
-                    char d = inputStr.charAt(i + 1);
-                    if (' ' == d || '\t' == d) {
-                        return true;
-                    }
+                if (followedByBlank(inputStr, i)) {
+                    return true;
                 }
                 break;
             default:
             }
         }
         return false;
+    }
+
+    private boolean precededByBlank(String inputStr, int offset) {
+        if (offset == 0) {
+            return true;
+        }
+        return isBlank(inputStr.charAt(offset - 1));
+    }
+
+    private boolean followedByBlank(String inputStr, int offset) {
+        if (offset == inputStr.length() - 1) {
+            return true;
+        }
+        return isBlank(inputStr.charAt(offset + 1));
+    }
+
+    private boolean isBlank(char value) {
+        return (' ' == value || '\t' == value);
     }
 
     /**
@@ -199,7 +211,7 @@ public abstract class StringQuotingChecker
         public Default() { }
 
         public static Default instance() { return INSTANCE; }
-        
+
         /**
          * Default implementation will call
          * {@link #isReservedKeyword(String)} and

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
@@ -119,25 +119,22 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
                 "key: f:off", yaml);
 
 
-        /* scenarios with single quoted scalars */
+        /* scenarios with double quoted scalars */
 
         content = Collections.singletonMap("key", "::");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();
         assertEquals("---\n" +
-                "key: '::'", yaml);
+                "key: \"::\"", yaml);
 
         content = Collections.singletonMap("key", "#");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();
         assertEquals("---\n" +
-                "key: '#'", yaml);
+                "key: \"#\"", yaml);
 
         content = Collections.singletonMap("key", "#a");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();
         assertEquals("---\n" +
-                "key: '#a'", yaml);
-
-
-        /* scenarios with double quoted scalars */
+                "key: \"#a\"", yaml);
 
         content = Collections.singletonMap("key", "a[b");
         yaml = MINIM_MAPPER.writeValueAsString(content).trim();


### PR DESCRIPTION
Scalar values starting with `#` or ending with `:` should be quoted. Currently, SnakeYAML will single-quote them automatically.  This change will proactively trigger the double quote style used for other values that require quotes when `MINIMIZE_QUOTES` is enabled.