### PR TITLE
remove synchronization from CsvMapper

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvMapper.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvMapper.java
@@ -472,19 +472,15 @@ public class CsvMapper extends ObjectMapper
             boolean typed, Class<?> view)
     {
         final ViewKey viewKey = new ViewKey(pojoType, view);
-        synchronized (schemas) {
-            CsvSchema s = schemas.get(viewKey);
-            if (s != null) {
-                return s;
-            }
+        CsvSchema s = schemas.get(viewKey);
+        if (s != null) {
+            return s;
         }
         final AnnotationIntrospector intr = _deserializationConfig.getAnnotationIntrospector();
         CsvSchema.Builder builder = CsvSchema.builder();
         _addSchemaProperties(builder, intr, typed, pojoType, null, view);
         CsvSchema result = builder.build();
-        synchronized (schemas) {
-            schemas.put(viewKey, result);
-        }
+        schemas.put(viewKey, result);
         return result;
     }
 


### PR DESCRIPTION
LRUMap can handle concurrent gets and puts.

The existing code does not stop 2 threads from getting null from the initial get and both creating new schemas and putting them to the LRUMap with the same key. We would need a more complicated solution to ensure that schemas were only created once. I don't think that we need that - the code is a good effort at avoiding creating schema instances over and over while avoiding the locking required to make it happen once and once only.