### PR TITLE
Add a way to distinguish between null and empty

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -338,6 +338,9 @@ public class CsvParser
      */
     protected boolean _cfgEmptyStringAsNull;
 
+    /**
+     * @since 2.18
+     */
     protected boolean _cfgEmptyUnquotedStringAsNull;
 
     /*
@@ -1042,7 +1045,6 @@ public class CsvParser
         if (_isNullValue(_currentValue)) {
             return JsonToken.VALUE_NULL;
         }
-
         return JsonToken.VALUE_STRING;
     }
 
@@ -1065,7 +1067,6 @@ public class CsvParser
         if (_isNullValue(next)) {
             return JsonToken.VALUE_NULL;
         }
-
         return JsonToken.VALUE_STRING;
     }
 
@@ -1106,7 +1107,6 @@ public class CsvParser
         if (_isNullValue(_currentValue)) {
             return JsonToken.VALUE_NULL;
         }
-
         return JsonToken.VALUE_STRING;
     }
 

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvParser.java
@@ -148,9 +148,12 @@ public class CsvParser
         INSERT_NULLS_FOR_MISSING_COLUMNS(false),
 
         /**
-         * Feature that enables coercing an empty {@link String} to `null`
+         * Feature that enables coercing an empty {@link String} to `null`.
+         *<p>
+         * Note that if this setting is enabled, {@link #EMPTY_UNQUOTED_STRING_AS_NULL}
+         * has no effect.
          *
-         * Feature is disabled by default
+         * Feature is disabled by default for backwards compatibility.
          */
         EMPTY_STRING_AS_NULL(false),
 
@@ -162,7 +165,9 @@ public class CsvParser
          * {@link #EMPTY_STRING_AS_NULL}
          * is disabled.
          *<p>
-         * Feature is disabled by default
+         * Feature is disabled by default for backwards compatibility.
+         *
+         * @since 2.18
          */
         EMPTY_UNQUOTED_STRING_AS_NULL(false),
         ;

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -155,6 +155,8 @@ public class CsvDecoder
 
     /**
      * Flag that indicates whether the current token has been quoted or not.
+     *
+     * @since 2.18
      */
     protected boolean _currInputQuoted = false;
 
@@ -414,6 +416,8 @@ public class CsvDecoder
     /**
      * Tell if the current token has been quoted or not.
      * @return True if the current token has been quoted, false otherwise
+     *
+     * @since 2.18
      */
     public final boolean isCurrentTokenQuoted() {
         return _currInputQuoted;

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -153,6 +153,11 @@ public class CsvDecoder
      */
     protected int _currInputRowStart = 0;
 
+    /**
+     * Flag that indicates whether the current token has been quoted or not.
+     */
+    protected boolean _currInputQuoted = false;
+
     // // // Location info at point when current token was started
 
     /**
@@ -404,6 +409,14 @@ public class CsvDecoder
             --ptr;
         }
         return ptr - _currInputRowStart + 1; // 1-based
+    }
+
+    /**
+     * Tell if the current token has been quoted or not.
+     * @return True if the current token has been quoted, false otherwise
+     */
+    public final boolean isCurrentTokenQuoted() {
+        return _currInputQuoted;
     }
     
     /*
@@ -673,7 +686,8 @@ public class CsvDecoder
             return "";
         }
         // two modes: quoted, unquoted
-        if (i == _quoteChar) { // offline quoted case (longer)
+        _currInputQuoted = i == _quoteChar; // Keep track of quoting
+        if (_currInputQuoted) { // offline quoted case (longer)
             return _nextQuotedString();
         }
         if (i == _separatorChar) {

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/EmptyUnquotedStringAsNullTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/EmptyUnquotedStringAsNullTest.java
@@ -1,0 +1,143 @@
+package com.fasterxml.jackson.dataformat.csv.deser;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.ModuleTestBase;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@code CsvParser.Feature.EMPTY_UNQUOTED_STRING_AS_NULL}
+ */
+public class EmptyUnquotedStringAsNullTest
+    extends ModuleTestBase
+{
+    @JsonPropertyOrder({"firstName", "middleName", "lastName"})
+    static class TestUser {
+        public String firstName, middleName, lastName;
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final CsvMapper MAPPER = mapperForCsv();
+
+    public void testDefaultParseAsEmptyString() throws IOException {
+        // setup test data
+        TestUser expectedTestUser = new TestUser();
+        expectedTestUser.firstName = "Grace";
+        expectedTestUser.middleName = "";
+        expectedTestUser.lastName = "Hopper";
+        ObjectReader objectReader = MAPPER.readerFor(TestUser.class).with(MAPPER.schemaFor(TestUser.class));
+        String csv = "Grace,,Hopper";
+
+        // execute
+        TestUser actualTestUser = objectReader.readValue(csv);
+
+        // test
+        assertNotNull(actualTestUser);
+        assertEquals(expectedTestUser.firstName, actualTestUser.firstName);
+        assertEquals(expectedTestUser.middleName, actualTestUser.middleName);
+        assertEquals(expectedTestUser.lastName, actualTestUser.lastName);
+    }
+
+    public void testSimpleParseEmptyUnquotedStringAsNull() throws IOException {
+        // setup test data
+        TestUser expectedTestUser = new TestUser();
+        expectedTestUser.firstName = "Grace";
+        expectedTestUser.lastName = "Hopper";
+
+        ObjectReader objectReader = MAPPER
+                .readerFor(TestUser.class)
+                .with(MAPPER.schemaFor(TestUser.class))
+                .with(CsvParser.Feature.EMPTY_UNQUOTED_STRING_AS_NULL);
+        String csv = "Grace,,Hopper";
+
+        // execute
+        TestUser actualTestUser = objectReader.readValue(csv);
+
+        // test
+        assertNotNull(actualTestUser);
+        assertEquals(expectedTestUser.firstName, actualTestUser.firstName);
+        assertNull("The column that contains an empty String should be deserialized as null ", actualTestUser.middleName);
+        assertEquals(expectedTestUser.lastName, actualTestUser.lastName);
+    }
+
+    public void testSimpleParseEmptyQuotedStringAsNonNull() throws IOException {
+        // setup test data
+        TestUser expectedTestUser = new TestUser();
+        expectedTestUser.firstName = "Grace";
+        expectedTestUser.middleName = "";
+        expectedTestUser.lastName = "Hopper";
+
+        ObjectReader objectReader = MAPPER
+                .readerFor(TestUser.class)
+                .with(MAPPER.schemaFor(TestUser.class))
+                .with(CsvParser.Feature.EMPTY_UNQUOTED_STRING_AS_NULL);
+        String csv = "Grace,\"\",Hopper";
+
+        // execute
+        TestUser actualTestUser = objectReader.readValue(csv);
+
+        // test
+        assertNotNull(actualTestUser);
+        assertEquals(expectedTestUser.firstName, actualTestUser.firstName);
+        assertEquals(expectedTestUser.middleName, actualTestUser.middleName);
+        assertEquals(expectedTestUser.lastName, actualTestUser.lastName);
+    }
+
+    // [dataformats-text#222]
+    public void testEmptyUnquotedStringAsNullNonPojo() throws Exception
+    {
+        String csv = "Grace,,Hopper";
+
+        ObjectReader r = MAPPER.reader()
+                .with(CsvParser.Feature.EMPTY_UNQUOTED_STRING_AS_NULL)
+                .with(CsvParser.Feature.WRAP_AS_ARRAY);
+
+        try (MappingIterator<Object[]> it1 =  r.forType(Object[].class).readValues(csv)) {
+            Object[] array1 = it1.next();
+            assertEquals(3, array1.length);
+            assertEquals("Grace", array1[0]);
+            assertNull(array1[1]);
+            assertEquals("Hopper", array1[2]);
+        }
+        try (MappingIterator<String[]> it2 =  r.forType(String[].class).readValues(csv)) {
+            String[] array2 = it2.next();
+            assertEquals(3, array2.length);
+            assertEquals("Grace", array2[0]);
+            assertNull(array2[1]);
+            assertEquals("Hopper", array2[2]);
+        }
+    }
+
+    public void testEmptyQuotedStringAsNonNullNonPojo() throws Exception
+    {
+        String csv = "Grace,\"\",Hopper";
+
+        ObjectReader r = MAPPER.reader()
+                .with(CsvParser.Feature.EMPTY_UNQUOTED_STRING_AS_NULL)
+                .with(CsvParser.Feature.WRAP_AS_ARRAY);
+
+        try (MappingIterator<Object[]> it1 =  r.forType(Object[].class).readValues(csv)) {
+            Object[] array1 = it1.next();
+            assertEquals(3, array1.length);
+            assertEquals("Grace", array1[0]);
+            assertEquals("", array1[1]);
+            assertEquals("Hopper", array1[2]);
+        }
+        try (MappingIterator<String[]> it2 =  r.forType(String[].class).readValues(csv)) {
+            String[] array2 = it2.next();
+            assertEquals(3, array2.length);
+            assertEquals("Grace", array2[0]);
+            assertEquals("", array2[1]);
+            assertEquals("Hopper", array2[2]);
+        }
+    }
+}


### PR DESCRIPTION
Following the issue: https://github.com/FasterXML/jackson-dataformats-text/issues/469

I made a pull request with that proposal:
- Add a new feature EMPTY_UNQUOTED_STRING_AS_NULL
- Implement it like EMPTY_STRING_AS_NULL
- Add tests

Note that I made this PR on the branch 2.18, but I'm using the version 2.15 in my projects (Spring boot 3.1)
If accepted we can move this feature also to previous versions