### PR TITLE
Allow passing `ParserImpl` by a subclass or overwrite the events

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -271,3 +271,9 @@ David Pujol (@PujolDavid)
 * Contributed #469: (csv) Allow CSV to differentiate between `null` and empty
   fields (foo,,bar vs. foo,"",bar)
  (2.18.0)
+
+Heiko Boettger (@HeikoBoettger)
+
+* Contributed #482: (yaml) Allow passing `ParserImpl` by a subclass or overwrite the events
+ (2.18.0)
+

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -21,6 +21,8 @@ Active Maintainers:
 #469: (csv) Allow CSV to differentiate between `null` and empty
   fields (foo,,bar vs. foo,"",bar)
  (contributed by David P)
+#482: (yaml) Allow passing `ParserImpl` by a subclass or overwrite the events
+ (contributed by Heiko B)
 
 2.17.2 (05-Jul-2024)
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -429,17 +429,6 @@ public class YAMLParser extends ParserBase
 
     // Note: SHOULD override 'getTokenLineNr', 'getTokenColumnNr', but those are final in 2.0
 
-    /**
-     * Since the parserImpl cannot be replaced allow subclasses to at least be able to
-     * influence the events being consumed.
-     *
-     * A particular use case is working around the lack of anchor and alias support to
-     * emit additional events.
-     */
-    protected Event getEvent() {
-        return _yamlParser.getEvent();
-    }
-    
     /*
     /**********************************************************
     /* Parsing
@@ -459,7 +448,7 @@ public class YAMLParser extends ParserBase
         while (true) {
             Event evt;
             try {
-                evt = _yamlParser.getEvent();
+                evt = getEvent();
             } catch (org.yaml.snakeyaml.error.YAMLException e) {
                 if (e instanceof org.yaml.snakeyaml.error.MarkedYAMLException) {
                     throw com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.from
@@ -587,6 +576,19 @@ public class YAMLParser extends ParserBase
                 return _updateTokenToNull();
             }
         }
+    }
+
+    /**
+     * Since the parserImpl cannot be replaced allow subclasses to at least be able to
+     * influence the events being consumed.
+     *
+     * A particular use case is working around the lack of anchor and alias support to
+     * emit additional events.
+     *
+     * @since 2.18
+     */
+    protected Event getEvent() {
+        return _yamlParser.getEvent();
     }
 
     protected JsonToken _decodeScalar(ScalarEvent scalar) throws IOException

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -192,14 +192,22 @@ public class YAMLParser extends ParserBase
     }
     
     public YAMLParser(IOContext ctxt, int parserFeatures, int formatFeatures,
-                      LoaderOptions loaderOptions, ObjectCodec codec, Reader reader)
+            LoaderOptions loaderOptions, ObjectCodec codec, Reader reader)
     {
-        this(ctxt, parserFeatures, formatFeatures, codec, 
-             new ParserImpl(new StreamReader(reader), (loaderOptions == null) ? new LoaderOptions() : loaderOptions))
+        this(ctxt, parserFeatures, formatFeatures, codec, reader,
+             new ParserImpl(new StreamReader(reader),
+                     (loaderOptions == null) ? new LoaderOptions() : loaderOptions));
     }
-    
+
+    /**
+     * Constructor to overload by custom parser sub-classes that want to replace
+     * {@link ParserImpl} passed.
+     *
+     * @since 2.18
+     */
     protected YAMLParser(IOContext ctxt, int parserFeatures, int formatFeatures,
-                      ObjectCodec codec, ParserImpl yamlParser)
+            ObjectCodec codec, Reader reader,
+            ParserImpl yamlParser)
     {
         super(ctxt, parserFeatures);
         _objectCodec = codec;
@@ -298,8 +306,10 @@ public class YAMLParser extends ParserBase
          *   Reader (granted, we only do that for UTF-32...) this
          *   means that buffer recycling won't work correctly.
          */
-        if (_ioContext.isResourceManaged() || isEnabled(JsonParser.Feature.AUTO_CLOSE_SOURCE)) {
-            _reader.close();
+        if (_reader != null) {
+            if (_ioContext.isResourceManaged() || isEnabled(JsonParser.Feature.AUTO_CLOSE_SOURCE)) {
+                _reader.close();
+            }
         }
     }
 
@@ -435,6 +445,7 @@ public class YAMLParser extends ParserBase
     /* Parsing
     /**********************************************************
      */
+
     @SuppressWarnings("deprecation")
     @Override
     public JsonToken nextToken() throws IOException

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLParser.java
@@ -179,7 +179,6 @@ public class YAMLParser extends ParserBase
     /**********************************************************************
      */
 
-
     /**
      * @deprecated since 2.14, use other constructor
      */
@@ -190,7 +189,7 @@ public class YAMLParser extends ParserBase
     {
         this(ctxt, parserFeatures, formatFeatures, null, codec, reader);
     }
-    
+
     public YAMLParser(IOContext ctxt, int parserFeatures, int formatFeatures,
             LoaderOptions loaderOptions, ObjectCodec codec, Reader reader)
     {


### PR DESCRIPTION
Makes it possible to overwrite the getEvent calls on the parser to add additional functionality such as filtering, modifying and inserting events. Alternatively provide a constructor to allow using subclasses of the snake yaml ParserImpl. Note: didn't replace the internal parserImpl-field since other subclasses might already use it otherwise would make sense to use the Parser-interface instead.

Why?

When using [networknt/json-schema-validator](https://github.com/networknt/json-schema-validator) with yaml files as data input format, I discovered that aliases and merges are not handled in a way that it is possible to validate the yaml files making use of this feature. While there are other discussions in the issue tracker to address this issue, I decided to manipulate the produced JsonTokens by instead of returning a VALUE_STRING producing JsonTolens as if the aliases were inlined the anchor. As it turned out it's simpler to hook into the getEvent-method and do the replacement on the snake yaml parser level. Since the code basically only invoked the getEvent-method of the parser in one place, I decided to extract a protected-method to overwrite it in my own code. This is the easiest way having to contribute a larger piece of code or having to completely copy the nextToken-method into my subclass.

Optionally I was thinking of injecting a subclass off the ParserImpl however that's also not possible, so I provide this option as well leaving other the choice how to extend the class.
