### PR TITLE
[`master`] fix failing tests after `FAIL_ON_NULL_FOR_PRIMITIVES` to `true` [databind#4890]

### DIFF
--- a/csv/src/test/java/tools/jackson/dataformat/csv/deser/BasicCSVParserTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/deser/BasicCSVParserTest.java
@@ -183,7 +183,9 @@ public class BasicCSVParserTest extends ModuleTestBase
         CsvSchema schema = MAPPER.typedSchemaFor(Point.class).withoutHeader();
 
         // First: empty value, to be considered as null
-        Point result = MAPPER.readerFor(Point.class).with(schema).readValue(",,\n");
+        Point result = MAPPER.readerFor(Point.class).with(schema)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .readValue(",,\n");
         assertEquals(0, result.x);
         assertNull(result.y);
         assertNull(result.z);
@@ -193,7 +195,9 @@ public class BasicCSVParserTest extends ModuleTestBase
         CsvSchema schema = MAPPER.typedSchemaFor(Point.class).withoutHeader();
 
         // First: empty value, to be considered as null
-        Point result = MAPPER.readerFor(Point.class).with(schema).readValue("null,null,null\n");
+        Point result = MAPPER.readerFor(Point.class).with(schema)
+                .without(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .readValue("null,null,null\n");
         assertEquals(0, result.x);
         assertNull(result.y);
         assertNull(result.z);

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/NumberDeserWithYAMLTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/NumberDeserWithYAMLTest.java
@@ -70,9 +70,7 @@ public class NumberDeserWithYAMLTest extends ModuleTestBase
     /**********************************************************************
      */
 
-    private final YAMLMapper MAPPER = mapperBuilder()
-            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-            .build();
+    private final YAMLMapper MAPPER = newObjectMapper();
 
     public void testNaN() throws Exception
     {
@@ -123,14 +121,18 @@ public class NumberDeserWithYAMLTest extends ModuleTestBase
         assertNull(MAPPER.readValue(NULL_JSON, Float.class));
         assertNull(MAPPER.readValue(NULL_JSON, Double.class));
 
-        assertEquals(Byte.valueOf((byte) 0), MAPPER.readValue(NULL_JSON, Byte.TYPE));
-        assertEquals(Short.valueOf((short) 0), MAPPER.readValue(NULL_JSON, Short.TYPE));
+        final YAMLMapper nullsOkMapper = mapperBuilder()
+                .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+                .build();
+
+        assertEquals(Byte.valueOf((byte) 0), nullsOkMapper.readValue(NULL_JSON, Byte.TYPE));
+        assertEquals(Short.valueOf((short) 0), nullsOkMapper.readValue(NULL_JSON, Short.TYPE));
 
         //        assertEquals(Character.valueOf((char) 0), MAPPER.readValue(JSON, Character.TYPE));
-        assertEquals(Integer.valueOf(0), MAPPER.readValue(NULL_JSON, Integer.TYPE));
-        assertEquals(Long.valueOf(0L), MAPPER.readValue(NULL_JSON, Long.TYPE));
-        assertEquals(Float.valueOf(0f), MAPPER.readValue(NULL_JSON, Float.TYPE));
-        assertEquals(Double.valueOf(0d), MAPPER.readValue(NULL_JSON, Double.TYPE));
+        assertEquals(Integer.valueOf(0), nullsOkMapper.readValue(NULL_JSON, Integer.TYPE));
+        assertEquals(Long.valueOf(0L), nullsOkMapper.readValue(NULL_JSON, Long.TYPE));
+        assertEquals(Float.valueOf(0f), nullsOkMapper.readValue(NULL_JSON, Float.TYPE));
+        assertEquals(Double.valueOf(0d), nullsOkMapper.readValue(NULL_JSON, Double.TYPE));
         
         assertNull(MAPPER.readValue(NULL_JSON, BigInteger.class));
         assertNull(MAPPER.readValue(NULL_JSON, BigDecimal.class));

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/NumberDeserWithYAMLTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/NumberDeserWithYAMLTest.java
@@ -70,7 +70,9 @@ public class NumberDeserWithYAMLTest extends ModuleTestBase
     /**********************************************************************
      */
 
-    private final YAMLMapper MAPPER = newObjectMapper();
+    private final YAMLMapper MAPPER = mapperBuilder()
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
     public void testNaN() throws Exception
     {


### PR DESCRIPTION
Resolves failing tests affected by https://github.com/FasterXML/jackson-databind/issues/4858