### PR TITLE
use shared MAPPER in ComplianceInvalidTest

### DIFF
--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ComplianceInvalidTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/ComplianceInvalidTest.java
@@ -29,7 +29,6 @@ public class ComplianceInvalidTest extends TomlMapperTestBase {
     @ParameterizedTest
     public void test(Path path) throws IOException {
         // Test implementation
-        ObjectMapper MAPPER = newTomlMapper();
         assertThrows(
                 TomlStreamReadException.class,
                 () -> MAPPER.readTree(path.toFile())


### PR DESCRIPTION
* class has a shared MAPPER instance
* might as well use it instead of not using it