### PR TITLE
add stream test to csv test case 497

### DIFF
--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.csv.deser;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
@@ -14,18 +15,30 @@ import static org.assertj.core.api.Assertions.fail;
 public class FuzzCSVReadTest extends StreamingCSVReadTest
 {
     private final CsvMapper CSV_MAPPER = mapperForCsv();
+    private final byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };
 
     // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50036
     @Test
     public void testUTF8Decoding50036() throws Exception
     {
-        byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };
         try {
             CSV_MAPPER.readTree(INPUT);
             fail("Should not pass");
         } catch (IOException e) {
             verifyException(e, "End-of-input after first 1 byte");
             verifyException(e, "of a UTF-8 character");
+        }
+    }
+
+    @Test
+    public void testUTF8Decoding50036Stream() throws Exception
+    {
+        byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };
+        try {
+            CSV_MAPPER.readTree(new ByteArrayInputStream(INPUT));
+            fail("Should not pass");
+        } catch (IOException e) {
+            verifyException(e, "Unexpected EOF in the middle of a multi-byte UTF-8 character");
         }
     }
 }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
@@ -33,7 +33,6 @@ public class FuzzCSVReadTest extends StreamingCSVReadTest
     @Test
     public void testUTF8Decoding50036Stream() throws Exception
     {
-        byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };
         try {
             CSV_MAPPER.readTree(new ByteArrayInputStream(INPUT));
             fail("Should not pass");

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/tofix/UnicodeCSVRead497Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/tofix/UnicodeCSVRead497Test.java
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.dataformat.csv.tofix;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
@@ -21,17 +22,33 @@ public class UnicodeCSVRead497Test extends ModuleTestBase
     @Test
     public void testUnicodeAtEnd() throws Exception
     {
-        StringBuilder sb = new StringBuilder(4001);
-        for (int i = 0; i < 4000; ++i) {
-            sb.append('a');
-        }
-        sb.append('\u5496');
-        String doc = sb.toString();
+        String doc = buildTestString();
         JsonNode o = MAPPER.reader() //.with(schema)
                 .readTree(doc.getBytes(StandardCharsets.UTF_8));
         assertNotNull(o);
         assertTrue(o.isArray());
         assertEquals(1, o.size());
         assertEquals(o.get(0).textValue(), doc);
+    }
+
+    @Test
+    public void testUnicodeAtEndStream() throws Exception
+    {
+        String doc = buildTestString();
+        JsonNode o = MAPPER.reader() //.with(schema)
+                .readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(o);
+        assertTrue(o.isArray());
+        assertEquals(1, o.size());
+        assertEquals(o.get(0).textValue(), doc);
+    }
+
+    private static String buildTestString() {
+        StringBuilder sb = new StringBuilder(4001);
+        for (int i = 0; i < 4000; ++i) {
+            sb.append('a');
+        }
+        sb.append('\u5496');
+        return sb.toString();
     }
 }


### PR DESCRIPTION
#497 issue only seems to happen with byte array input - work ok with InputStream input.

When byte array input to UTF8Reader, the _inputSource is always null and the _ioContext is null which is what is checked in `canModifyBuffer()`. Is there any way that this code can be adjusted to work for byte array input - or should we take the byte array and wrap as ByteArrayInputStream? - which would also fix the broken test.

The code that causes the issue.
https://github.com/FasterXML/jackson-dataformats-text/blob/9a38ea20f2733d790e9457418efbb92578b64ae6/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java#L406-L418

Needed for a fuzz test to work but also breaks the 497 test.