### PR TITLE
add csv tests where the 3 byte char is 2nd last

### DIFF
--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/tofix/UnicodeCSVRead497Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/tofix/UnicodeCSVRead497Test.java
@@ -32,9 +32,33 @@ public class UnicodeCSVRead497Test extends ModuleTestBase
     }
 
     @Test
+    public void testUnicodeAtEnd2() throws Exception
+    {
+        String doc = buildTestString2();
+        JsonNode o = MAPPER.reader() //.with(schema)
+                .readTree(doc.getBytes(StandardCharsets.UTF_8));
+        assertNotNull(o);
+        assertTrue(o.isArray());
+        assertEquals(1, o.size());
+        assertEquals(o.get(0).textValue(), doc);
+    }
+
+    @Test
     public void testUnicodeAtEndStream() throws Exception
     {
         String doc = buildTestString();
+        JsonNode o = MAPPER.reader() //.with(schema)
+                .readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(o);
+        assertTrue(o.isArray());
+        assertEquals(1, o.size());
+        assertEquals(o.get(0).textValue(), doc);
+    }
+
+    @Test
+    public void testUnicodeAtEndStream2() throws Exception
+    {
+        String doc = buildTestString2();
         JsonNode o = MAPPER.reader() //.with(schema)
                 .readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8)));
         assertNotNull(o);
@@ -49,6 +73,16 @@ public class UnicodeCSVRead497Test extends ModuleTestBase
             sb.append('a');
         }
         sb.append('\u5496');
+        return sb.toString();
+    }
+
+    private static String buildTestString2() {
+        StringBuilder sb = new StringBuilder(4001);
+        for (int i = 0; i < 3999; ++i) {
+            sb.append('a');
+        }
+        sb.append('\u5496');
+        sb.append('b');
         return sb.toString();
     }
 }


### PR DESCRIPTION
* seems like the CSV UTF8Reader does better when the 3 byte char is 2nd last and not last