### PR TITLE
csv: remove old workaround in UTF8Reader

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
@@ -84,8 +84,8 @@ public final class UTF8Reader
         _inputPtr = ptr;
         _inputEnd = ptr+len;
         _autoClose = autoClose;
-        // Unmodifiable if there is no stream to actually read
-        // (ideally should pass explicitly)
+        // Unmodifiable if there is no stream to actually read from
+        // (ideally caller should pass explicitly)
         _inputBufferReadOnly = (in == null);
     }
 

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.dataformat.csv.impl;
 
 import java.io.*;
-import java.util.Arrays;
 
 import com.fasterxml.jackson.core.io.IOContext;
 
@@ -34,7 +33,7 @@ public final class UTF8Reader
      *
      * @since 2.19
      */
-    private boolean _inputBufferReadOnly;
+    private final boolean _inputBufferReadOnly;
 
     /**
      * Pointer to the next available byte (if any), iff less than
@@ -409,20 +408,17 @@ public final class UTF8Reader
     {
         _byteCount += (_inputEnd - available);
 
-        // Bytes that need to be moved to the beginning of buffer?
         if (available > 0) {
+            // Should we move bytes to the beginning of buffer?
             if (_inputPtr > 0) {
-                if (_inputBufferReadOnly) {
-                    // _inputBuffer needs to be copied to avoid modifying original
-                    _inputBuffer = Arrays.copyOfRange(_inputBuffer, _inputPtr, _inputEnd);
-                    _inputBufferReadOnly = false;
-                } else {
+                // Can only do so if buffer mutable
+                if (!_inputBufferReadOnly) {
                     for (int i = 0; i < available; ++i) {
                         _inputBuffer[i] = _inputBuffer[_inputPtr+i];
                     }
+                    _inputPtr = 0;
+                    _inputEnd = available;
                 }
-                _inputPtr = 0;
-                _inputEnd = available;
             }
         } else {
             // Ok; here we can actually reasonably expect an EOF, so let's do a separate read right away:

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
@@ -403,6 +403,17 @@ public final class UTF8Reader
         // Bytes that need to be moved to the beginning of buffer?
         if (available > 0) {
             if (_inputPtr > 0) {
+                if (!canModifyBuffer()) {
+                    // 15-Aug-2022, tatu: Occurs (only) if we have half-decoded UTF-8
+                    //     characters; uncovered by:
+                    //
+                    // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50036
+                    //
+                    // _inputBuffer needs to be cloned to avoid modifying original
+                    if (_inputSource == null) {
+                        _inputBuffer = _inputBuffer.clone();
+                    }
+                }
                 for (int i = 0; i < available; ++i) {
                     _inputBuffer[i] = _inputBuffer[_inputPtr+i];
                 }

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/impl/UTF8Reader.java
@@ -403,19 +403,6 @@ public final class UTF8Reader
         // Bytes that need to be moved to the beginning of buffer?
         if (available > 0) {
             if (_inputPtr > 0) {
-                if (!canModifyBuffer()) {
-                    // 15-Aug-2022, tatu: Occurs (only) if we have half-decoded UTF-8
-                    //     characters; uncovered by:
-                    //
-                    // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50036
-                    //
-                    // and need to be reported as IOException
-                    if (_inputSource == null) {
-                        throw new IOException(String.format(
-"End-of-input after first %d byte(s) of a UTF-8 character: needed at least one more",
-available));
-                    }
-                }
                 for (int i = 0; i < available; ++i) {
                     _inputBuffer[i] = _inputBuffer[_inputPtr+i];
                 }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
@@ -25,8 +25,7 @@ public class FuzzCSVReadTest extends StreamingCSVReadTest
             CSV_MAPPER.readTree(INPUT);
             fail("Should not pass");
         } catch (IOException e) {
-            verifyException(e, "End-of-input after first 1 byte");
-            verifyException(e, "of a UTF-8 character");
+            verifyException(e, "Unexpected EOF in the middle of a multi-byte UTF-8 character");
         }
     }
 

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Collection of OSS-Fuzz found issues for CSV format module.
@@ -16,6 +18,7 @@ public class FuzzCSVReadTest extends StreamingCSVReadTest
 {
     private final CsvMapper CSV_MAPPER = mapperForCsv();
     private final byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };
+    private final byte[] CLONED = INPUT.clone();
 
     // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50036
     @Test
@@ -26,6 +29,8 @@ public class FuzzCSVReadTest extends StreamingCSVReadTest
             fail("Should not pass");
         } catch (IOException e) {
             verifyException(e, "Unexpected EOF in the middle of a multi-byte UTF-8 character");
+            // check input was not modified
+            assertArrayEquals(CLONED, INPUT);
         }
     }
 
@@ -37,6 +42,8 @@ public class FuzzCSVReadTest extends StreamingCSVReadTest
             fail("Should not pass");
         } catch (IOException e) {
             verifyException(e, "Unexpected EOF in the middle of a multi-byte UTF-8 character");
+            // check input was not modified
+            assertArrayEquals(CLONED, INPUT);
         }
     }
 }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/FuzzCSVReadTest.java
@@ -6,15 +6,15 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.ModuleTestBase;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Collection of OSS-Fuzz found issues for CSV format module.
  */
-public class FuzzCSVReadTest extends StreamingCSVReadTest
+public class FuzzCSVReadTest extends ModuleTestBase
 {
     private final CsvMapper CSV_MAPPER = mapperForCsv();
     private final byte[] INPUT = new byte[] { 0x20, (byte) 0xCD };

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/UnicodeCSVRead497Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/UnicodeCSVRead497Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.csv.tofix;
+package com.fasterxml.jackson.dataformat.csv.deser;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.ModuleTestBase;
-import com.fasterxml.jackson.dataformat.csv.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,7 +17,6 @@ public class UnicodeCSVRead497Test extends ModuleTestBase
     private final CsvMapper MAPPER = mapperForCsv();
 
     // [dataformats-text#497]
-    @JacksonTestFailureExpected
     @Test
     public void testUnicodeAtEnd() throws Exception
     {

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/UnicodeCSVRead497Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/deser/UnicodeCSVRead497Test.java
@@ -33,12 +33,15 @@ public class UnicodeCSVRead497Test extends ModuleTestBase
     public void testUnicodeAtEnd2() throws Exception
     {
         String doc = buildTestString2();
+        final byte[] bytes = doc.getBytes(StandardCharsets.UTF_8);
         JsonNode o = MAPPER.reader() //.with(schema)
-                .readTree(doc.getBytes(StandardCharsets.UTF_8));
+                .readTree(bytes);
         assertNotNull(o);
         assertTrue(o.isArray());
         assertEquals(1, o.size());
         assertEquals(o.get(0).textValue(), doc);
+        // check byte array was not modified
+        assertArrayEquals(doc.getBytes(StandardCharsets.UTF_8), bytes);
     }
 
     @Test


### PR DESCRIPTION
* relates to #545 
* the fuzz test still behaves very similarly - just the exception message changes a little
* fixes the test for #497