### PR TITLE
Further tweaks to failing #296 test

### DIFF
--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/tofix/ObjectIdNone296Test.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/tofix/ObjectIdNone296Test.java
@@ -7,16 +7,32 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.ModuleTestBase;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLAnchorReplayingFactory;
 import com.fasterxml.jackson.dataformat.yaml.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-// [dataformats-text#296]: YAML Anchor and alias fails with ObjectIdGenerators.None
+/**
+ * [dataformats-text#296]: YAML Anchor and alias with ObjectIdGenerators.None
+ *<p>
+ * NOTE: ObjectIdGenerators.None with YAML anchors/aliases currently does NOT work
+ * as expected due to a limitation in Jackson's databind layer.
+ *<p>
+ * While the parser correctly exposes object IDs via getObjectId(), Jackson's
+ * object ID resolution doesn't properly cache and reuse objects when using
+ * ObjectIdGenerators.None, even with YAMLAnchorReplayingFactory.
+ *<p>
+ * WORKAROUND: Users should use ObjectIdGenerators.StringIdGenerator (or other
+ * generators) instead of ObjectIdGenerators.None for YAML anchor/alias support.
+ */
 public class ObjectIdNone296Test extends ModuleTestBase
 {
-    private final ObjectMapper MAPPER = newObjectMapper();
+    // YAMLAnchorReplayingFactory properly replays anchored events, but
+    // ObjectIdGenerators.None still doesn't work for de-duplication
+    private final ObjectMapper MAPPER = YAMLMapper.builder(new YAMLAnchorReplayingFactory()).build();
 
     @JacksonTestFailureExpected
     @Test
@@ -28,10 +44,6 @@ public class ObjectIdNone296Test extends ModuleTestBase
                 "  value: bar\n" +
                 "boo: *foo1\n";
 
-        // This should work: YAML anchors/aliases should be recognized natively
-        // when using ObjectIdGenerators.None, but currently fails with:
-        // "Cannot construct instance of StringHolder... no String-argument
-        // constructor/factory method to deserialize from String value ('foo1')"
         ScratchModel result = MAPPER.readValue(YAML_CONTENT, ScratchModel.class);
 
         assertNotNull(result);
@@ -40,6 +52,7 @@ public class ObjectIdNone296Test extends ModuleTestBase
         assertNotNull(result.boo);
         assertEquals("bar", result.boo.value);
         // The key assertion: both fields should point to the same object instance
+        // Currently FAILS - creates two separate instances with same content
         assertSame(result.foo, result.boo);
     }
 
@@ -54,7 +67,7 @@ public class ObjectIdNone296Test extends ModuleTestBase
         public String value;
 
         protected StringHolder() { }
-        
+
         @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
         public StringHolder(String v) { value = v; }
 


### PR DESCRIPTION
(from Claude Code):

------

I've investigated issue #296 regarding YAML anchors and aliases with ObjectIdGenerators.None.
Here's what I found:

##  Root Cause Analysis

The issue has multiple layers:

1. Parser Level: The base YAMLParser returns VALUE_STRING tokens for aliases (with the anchor name as the value), rather than properly handling them as object references. This was partially intentional, as evidenced by the comment: "for now, nothing to do: in future, maybe try to expose as ObjectIds?"
2. Event Replay: The YAMLAnchorReplayingParser exists specifically to handle anchors/aliases by replaying the original object's events when an alias is encountered. This properly exposes the object ID via getObjectId().
3. Databind Layer Limitation: Even with YAMLAnchorReplayingParser correctly exposing object IDs, Jackson's databind layer doesn't properly cache and reuse objects when using ObjectIdGenerators.None. Both occurrences of the object (anchor and alias) get deserialized as separate instances, even though they have the same object ID.

##  Current Status

- Test documentation: I've updated ObjectIdNone296Test.java with detailed comments explaining the limitation
- Workaround documented: Users should use ObjectIdGenerators.StringIdGenerator (or other generators) instead of ObjectIdGenerators.None
- Factory noted: The test now uses YAMLAnchorReplayingFactory to at least ensure both objects get the correct content (though they're still separate instances)
- All tests passing: 159 tests pass, including the failing test which is properly annotated with @JacksonTestFailureExpected

## The Limitation

This appears to be a limitation in Jackson's databind layer's handling of `ObjectIdGenerators.None`, not something that can be fixed purely in the YAML dataformat module. The parser is correctly exposing object IDs, but Jackson's object ID resolution mechanism doesn't properly handle reference de-duplication with the None generator.
