### PR TITLE
Fixes #10: missing `null` writes with `Object[]`

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -238,6 +238,14 @@ public class CsvGenerator extends GeneratorBase
     protected boolean _skipValue;
 
     /**
+     * Flag set when a row has just been finished, used to distinguish between
+     * null values within a row vs null rows.
+     *
+     * @since 2.21
+     */
+    protected boolean _justFinishedRow = false;
+
+    /**
      * Separator to use during writing of (simple) array value, to be encoded as a
      * single column value, if any.
      *
@@ -562,6 +570,7 @@ public class CsvGenerator extends GeneratorBase
     public final void writeStartArray() throws IOException
     {
         _verifyValueWrite("start an array");
+        _justFinishedRow = false; // Clear flag when starting new array
         // Ok to create root-level array to contain Objects/Arrays, but
         // can not nest arrays in objects
         if (_tokenWriteContext.inObject()) {
@@ -882,7 +891,12 @@ public class CsvGenerator extends GeneratorBase
                 //   just skip; can change, if so desired, to expose "root null" as empty rows, possibly
                 //   based on either schema property, or CsvGenerator.Feature.
                 //  Note: if nulls are to be written that way, would need to call `finishRow()` right after `writeNull()`
-                if (!_tokenWriteContext.getParent().inRoot()) {
+                // [dataformats-text#10]: When we have a schema and we haven't just finished a row,
+                //   it means we're inside an array-as-row (like Object[]), so null is a column value
+                boolean writeNullValue = !_tokenWriteContext.getParent().inRoot()
+                    || (_schema.size() > 0 && !_justFinishedRow);
+
+                if (writeNullValue) {
                     // 26-Aug-2024, tatu: [dataformats-text#495] Decorations?
                     if (_nextColumnDecorator != null) {
                         String nvl = _nextColumnDecorator.decorateNull(this);
@@ -1132,6 +1146,7 @@ public class CsvGenerator extends GeneratorBase
     {
         _writer.endRow();
         _nextColumnByName = -1;
+        _justFinishedRow = true;
     }
 
     protected void _handleFirstLine() throws IOException

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvGenerator.java
@@ -240,6 +240,7 @@ public class CsvGenerator extends GeneratorBase
     /**
      * Flag set when a row has just been finished, used to distinguish between
      * null values within a row vs null rows.
+     * Only relevant for Array-wrapped rows.
      *
      * @since 2.21
      */
@@ -645,6 +646,8 @@ public class CsvGenerator extends GeneratorBase
     public final void writeStartObject() throws IOException
     {
         _verifyValueWrite("start an object");
+        _justFinishedRow = false;
+
         // No nesting for objects; can write Objects inside logical root-level arrays.
         // 14-Dec-2015, tatu: ... except, should be fine if we are ignoring the property
         if (_tokenWriteContext.inObject() ||

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite10Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite10Test.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ObjectArrayNullWrite10Test extends ModuleTestBase
 {
-    private final CsvMapper MAPPER = mapperForCsv();
-
     // for [dataformats-text#10]
     @Test
     public void testNullsOnObjectArrayWrites2Col() throws Exception
@@ -23,13 +21,14 @@ public class ObjectArrayNullWrite10Test extends ModuleTestBase
                 .addColumn("b", CsvSchema.ColumnType.NUMBER)
                 .setUseHeader(true)
                 .build();
-        ObjectWriter writer = MAPPER.writer(schema);
+        ObjectWriter writer = mapperForCsv().writer(schema);
         StringWriter out = new StringWriter();
-        SequenceWriter sequence = writer.writeValues(out);
 
-        sequence.write(new Object[]{ null, 2 });
-        sequence.write(new Object[]{ null, null });
-        sequence.write(new Object[]{ 1, null });
+        try (SequenceWriter sequence = writer.writeValues(out)) {
+            sequence.write(new Object[]{ null, 2 });
+            sequence.write(new Object[]{ null, null });
+            sequence.write(new Object[]{ 1, null });
+        }
 
         final String csv = out.toString().trim();
 

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite10Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite10Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.csv.tofix;
+package com.fasterxml.jackson.dataformat.csv.ser;
 
 import java.io.StringWriter;
 
@@ -7,16 +7,14 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.*;
-import com.fasterxml.jackson.dataformat.csv.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MissingNullsOnObjectArrayWrite10Test extends ModuleTestBase
+public class ObjectArrayNullWrite10Test extends ModuleTestBase
 {
     private final CsvMapper MAPPER = mapperForCsv();
 
     // for [dataformats-text#10]
-    @JacksonTestFailureExpected
     @Test
     public void testNullsOnObjectArrayWrites2Col() throws Exception
     {

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite116Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite116Test.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ObjectArrayNullWrite116Test extends ModuleTestBase
 {
-    private final CsvMapper MAPPER = mapperForCsv();
-
     // for [dataformats-text#116]
     @Test
     public void testWithObjectArray() throws Exception
@@ -23,18 +21,19 @@ public class ObjectArrayNullWrite116Test extends ModuleTestBase
                                     .addColumn("b", CsvSchema.ColumnType.NUMBER)
                                     .setUseHeader(true)
                                     .build();
-        ObjectWriter writer = MAPPER.writer(schema);
+        ObjectWriter writer = mapperForCsv().writer(schema);
         StringWriter out = new StringWriter();
-        SequenceWriter sequence = writer.writeValues(out);
 
-        sequence.write(new Object[]{ 1, 2 });
-        sequence.write(new Object[]{ null, null });
-        sequence.write(new Object[]{ 1, null });
-
-        sequence.close();
+        try (SequenceWriter sequence = writer.writeValues(out)) {
+            sequence.write(new Object[]{ 1, 2 });
+            sequence.write(new Object[]{ null, 2 });
+            sequence.write(new Object[]{ null, null });
+            sequence.write(new Object[]{ 1, null });
+        }
 
         assertEquals("a,b\n" +
                      "1,2\n" +
+                     ",2\n" +
                      ",\n" +
                      "1,\n", out.toString());
     }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite116Test.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/ser/ObjectArrayNullWrite116Test.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.dataformat.csv.tofix;
+package com.fasterxml.jackson.dataformat.csv.ser;
 
 import java.io.StringWriter;
 
@@ -7,41 +7,35 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.*;
-import com.fasterxml.jackson.dataformat.csv.testutil.failure.JacksonTestFailureExpected;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class NullWriting116Test extends ModuleTestBase
+public class ObjectArrayNullWrite116Test extends ModuleTestBase
 {
-    private final CsvMapper csv = mapperForCsv();
+    private final CsvMapper MAPPER = mapperForCsv();
 
-    // [dataformat#116]
-    @JacksonTestFailureExpected
+    // for [dataformats-text#116]
     @Test
-    public void testWithObjectArray() throws Exception 
+    public void testWithObjectArray() throws Exception
     {
         CsvSchema schema = CsvSchema.builder()
                                     .addColumn("a", CsvSchema.ColumnType.NUMBER)
                                     .addColumn("b", CsvSchema.ColumnType.NUMBER)
                                     .setUseHeader(true)
                                     .build();
-        ObjectWriter writer = csv.writer(schema);
+        ObjectWriter writer = MAPPER.writer(schema);
         StringWriter out = new StringWriter();
         SequenceWriter sequence = writer.writeValues(out);
 
         sequence.write(new Object[]{ 1, 2 });
-//        sequence.write(new Object[]{ null, 2 });
         sequence.write(new Object[]{ null, null });
         sequence.write(new Object[]{ 1, null });
 
         sequence.close();
 
-//System.err.println("CSV:\n"+out);
         assertEquals("a,b\n" +
                      "1,2\n" +
-//                     ",2\n" +
                      ",\n" +
                      "1,\n", out.toString());
     }
-
 }

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,8 @@ Active Maintainers:
 
 2.21.0 (not yet released)
 
-No changes since 2.20
+#10: Missing `null` writes when writing `Object[]` values
+ (fix by @cowtowncoder, w/ Claude code)
 
 2.20.1 (30-Oct-2025)
 


### PR DESCRIPTION
Claude-assisted attempt to fix #10 -- not sure if valid, solves tests but... need to review carefully.

Also fully fixes #116 (was marked as fixed but had failing test)
