### PR TITLE
Fix YAML anchor replaying parser producing invalid sequence of events when using the merge operator inside an anchor

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -20,6 +20,9 @@ Théo SZANTO (@indyteo)
 * Contributed #596: (yaml) Port `YAMLAnchorReplayingFactory` from 2.x and improve it
   to handle nested anchors
  (3.1.0)
+* Fixed #624: (yaml) Fix YAML anchor replaying parser producing invalid sequence of events
+  when using the merge operator inside an anchor
+ (3.1.1)
 
 Dmitry Bufistov (@dmitry-workato)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,9 @@ No changes since 3.1
 
 #615: (csv) Feature `CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL` ignored
  (reported by Henning L)
+#624: (yaml) Fix YAML anchor replaying parser producing invalid sequence of events
+  when using the merge operator inside an anchor
+ (fix by Théo S)
 
 3.1.0 (23-Feb-2026)
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLAnchorReplayingParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLAnchorReplayingParser.java
@@ -137,10 +137,15 @@ public class YAMLAnchorReplayingParser extends YAMLParser {
 
     @Override
     protected Event nextEvent() {
+        return nextEvent(true);
+    }
+
+    protected Event nextEvent(boolean recordEvents) {
         while (!refEvents.isEmpty()) {
             Event event = filterEvent(trackDepth(refEvents.removeFirst()));
             if (event != null) {
-                recordEvent(event);
+                if (recordEvents)
+                    recordEvent(event);
                 return event;
             }
         }
@@ -158,7 +163,7 @@ public class YAMLAnchorReplayingParser extends YAMLParser {
                 if (refEvents.size() + events.size() > MAX_EVENTS)
 					throw new StreamConstraintsException("too many events to replay");
                 refEvents.addAll(events);
-                return nextEvent();
+                return nextEvent(recordEvents);
             }
             _reportError("invalid alias: " + alias.getAlias());
         }
@@ -184,18 +189,20 @@ public class YAMLAnchorReplayingParser extends YAMLParser {
         if (event instanceof ScalarEvent scalarEvent) {
             if (scalarEvent.getValue().equals("<<")) {
                 // expect next node to be a map
-                Event next = nextEvent();
+                // this mapping start event must not be registered by anchors; it is dropped so the contents are merged
+                Event next = nextEvent(false);
                 if (next instanceof MappingStartEvent) {
                     if (mergeStack.size() + 1 > MAX_MERGES)
 						throw new StreamConstraintsException("too many merges in the document");
                     mergeStack.push(globalDepth);
-                    return nextEvent();
+                    return nextEvent(recordEvents);
                 }
                 _reportError("found field '<<' but value isn't a map");
             }
         }
 
-        recordEvent(event);
+        if (recordEvents)
+            recordEvent(event);
         return event;
     }
 }

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLAnchorReplayingParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLAnchorReplayingParser.java
@@ -20,9 +20,10 @@ import tools.jackson.core.util.BufferRecycler;
  * Note: this overwrites the nextEvent() since the base {@code super.nextToken()}
  * manages too much state, and it seems to be much simpler to re-emit the events.
  *
- * @since 2.19
+ * @since 2.19 / 3.1
  */
-public class YAMLAnchorReplayingParser extends YAMLParser {
+public class YAMLAnchorReplayingParser extends YAMLParser
+{
     private static class AnchorContext {
         public final String anchor;
         public final List<Event> events = new ArrayList<>();
@@ -140,12 +141,14 @@ public class YAMLAnchorReplayingParser extends YAMLParser {
         return nextEvent(true);
     }
 
+    // @since 3.1.1
     protected Event nextEvent(boolean recordEvents) {
         while (!refEvents.isEmpty()) {
             Event event = filterEvent(trackDepth(refEvents.removeFirst()));
             if (event != null) {
-                if (recordEvents)
+                if (recordEvents) {
                     recordEvent(event);
+                }
                 return event;
             }
         }
@@ -201,8 +204,9 @@ public class YAMLAnchorReplayingParser extends YAMLParser {
             }
         }
 
-        if (recordEvents)
+        if (recordEvents) {
             recordEvent(event);
+        }
         return event;
     }
 }

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ModuleTestBase.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ModuleTestBase.java
@@ -134,6 +134,15 @@ public abstract class ModuleTestBase
             assertEquals(expOrig, actOrig);
         }
     }
+
+    protected void assertLocation(JsonParser jp, int lineNr, int columnNr, int charOffset, int byteOffset)
+    {
+        TokenStreamLocation loc = jp.currentTokenLocation();
+        assertEquals(lineNr, loc.getLineNr());
+        assertEquals(columnNr, loc.getColumnNr());
+        assertEquals(charOffset, loc.getCharOffset());
+        assertEquals(byteOffset, loc.getByteOffset());
+    }
     
     /**
      * Method that gets textual contents of the current token using

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLAnchorReplayingParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLAnchorReplayingParseTest.java
@@ -333,4 +333,94 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
 
         p.close();
     }
+
+    @Test
+    public void testMergeInsideAnchor() {
+        final String YAML = """
+            objToMerge: &mergeAnchor
+              val1: a
+              val2: b
+            obj1: &objAnchor
+              <<: *mergeAnchor
+              val3: c
+            obj2: *objAnchor
+            """;
+        JsonParser p = MAPPER.createParser(YAML);
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("objToMerge", p.getString());
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertLocation(p, 1, 13, 12, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val1", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("a", p.getString());
+        assertLocation(p, 2, 9, 33, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val2", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("b", p.getString());
+        assertLocation(p, 3, 9, 43, -1);
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("obj1", p.getString());
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertLocation(p, 4, 7, 51, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val1", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("a", p.getString());
+        assertLocation(p, 2, 9, 33, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val2", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("b", p.getString());
+        assertLocation(p, 3, 9, 43, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val3", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("c", p.getString());
+        assertLocation(p, 6, 9, 89, -1);
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("obj2", p.getString());
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+        assertLocation(p, 4, 7, 51, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val1", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("a", p.getString());
+        assertLocation(p, 2, 9, 33, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val2", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("b", p.getString());
+        assertLocation(p, 3, 9, 43, -1);
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("val3", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("c", p.getString());
+        assertLocation(p, 6, 9, 89, -1);
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+
+        assertNull(p.nextToken());
+
+        p.close();
+    }
 }

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLAnchorReplayingParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLAnchorReplayingParseTest.java
@@ -1,7 +1,6 @@
 package tools.jackson.dataformat.yaml.deser;
 
 import org.junit.jupiter.api.Test;
-import tools.jackson.core.TokenStreamLocation;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 
@@ -31,20 +30,12 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(8, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 9, 8, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
         assertEquals("true", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(21, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 7, 21, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());
@@ -85,41 +76,25 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertEquals("string1", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("textValue", p.getString());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(10, loc.getColumnNr());
-        assertEquals(9, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 10, 9, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string2", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("textValue", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(10, loc.getColumnNr());
-        assertEquals(9, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 10, 9, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("int1", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("123", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(64, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 7, 64, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("int2", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("123", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(64, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 7, 64, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
         assertNull(p.nextToken());
@@ -146,27 +121,15 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("1", p.getString());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(23, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 5, 23, -1);
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("2", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(29, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 5, 29, -1);
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("3", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(4, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(35, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 4, 5, 35, -1);
 
         assertToken(JsonToken.END_ARRAY, p.nextToken());
 
@@ -176,27 +139,15 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("1", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(23, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 5, 23, -1);
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("2", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(29, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 5, 29, -1);
 
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals("3", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(4, loc.getLineNr());
-        assertEquals(5, loc.getColumnNr());
-        assertEquals(35, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 4, 5, 35, -1);
 
         assertToken(JsonToken.END_ARRAY, p.nextToken());
 
@@ -221,60 +172,36 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj1", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(6, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 7, 6, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(11, loc.getColumnNr());
-        assertEquals(27, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 11, 27, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(42, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 9, 42, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj2", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(6, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 7, 6, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(11, loc.getColumnNr());
-        assertEquals(27, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 11, 27, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(42, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 9, 42, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
@@ -301,69 +228,41 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj1", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(6, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 7, 6, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(11, loc.getColumnNr());
-        assertEquals(27, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 11, 27, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(42, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 9, 42, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj2", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(5, loc.getLineNr());
-        assertEquals(3, loc.getColumnNr());
-        assertEquals(55, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 5, 3, 55, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(11, loc.getColumnNr());
-        assertEquals(27, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 11, 27, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(3, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(42, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 3, 9, 42, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("int", p.getString());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(6, loc.getLineNr());
-        assertEquals(8, loc.getColumnNr());
-        assertEquals(77, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 6, 8, 77, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
@@ -390,69 +289,41 @@ public class StreamingYAMLAnchorReplayingParseTest extends ModuleTestBase {
         assertEquals("value", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(8, loc.getColumnNr());
-        assertEquals(7, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 8, 7, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj1", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(31, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 7, 31, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(8, loc.getColumnNr());
-        assertEquals(7, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 8, 7, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(4, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(71, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 4, 9, 71, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("obj2", p.getString());
         assertToken(JsonToken.START_OBJECT, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(31, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 7, 31, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("string", p.getString());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("text", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(8, loc.getColumnNr());
-        assertEquals(7, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 8, 7, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertEquals("bool", p.getString());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
-        loc = p.currentTokenLocation();
-        assertEquals(4, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(71, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 4, 9, 71, -1);
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import org.snakeyaml.engine.v2.api.LoadSettings;
 
-import tools.jackson.core.TokenStreamLocation;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
 import tools.jackson.dataformat.yaml.JacksonYAMLParseException;
@@ -52,20 +51,12 @@ public class StreamingYAMLParseTest extends ModuleTestBase
         assertEquals("text", p.getString());
         assertEquals("text", p.getValueAsString());
         assertEquals("text", p.getValueAsString("x"));
-        TokenStreamLocation loc = p.currentTokenLocation();
-        assertEquals(1, loc.getLineNr());
-        assertEquals(9, loc.getColumnNr());
-        assertEquals(8, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 1, 9, 8, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertToken(JsonToken.VALUE_TRUE, p.nextToken());
         assertEquals("true", p.getString());
-        loc = p.currentTokenLocation();
-        assertEquals(2, loc.getLineNr());
-        assertEquals(7, loc.getColumnNr());
-        assertEquals(21, loc.getCharOffset());
-        assertEquals(-1, loc.getByteOffset());
+        assertLocation(p, 2, 7, 21, -1);
 
         assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
         assertToken(JsonToken.VALUE_FALSE, p.nextToken());


### PR DESCRIPTION
Hi,

Few months ago, I contributed a change (#596) to the `YAMLAnchorReplayingParser` to port it to 3.x and also to fix an issue regarding nested anchors handling. I tested the fix in various scenarios, but it seems that I forgot one edge case: When using the merge operator (`<<`) to reference an anchor (`*ref`), while being inside the definition of another anchor (`&anchor`), the `MappingStartEvent` of the referenced anchor (`ref`) gets recorded in the other anchor (`anchor`), thus resulting in an invalid sequence of events (2 mapping starts for 1 mapping end) when replaying that other anchor (`*anchor`). Depending on when the second anchor was replayed, it may have resulted either in an unknown alias (`anchor` definition being considered incomplete yet) or a random parsing exception because of a token mismatch (a mapping start right after another mapping start, instead of having a field name in-between).

<details>
<summary>Some YAML examples that were failing</summary>

```yaml
ref: &ref
  some: value
obj1: &anchor
  # first mapping start here
  <<: *ref # the bug: an extra mapping start event is recorded here,
           # making the algorithm recording the anchor believe it needs to
           # wait for an extra mapping end before the anchor is complete
  other: value
  # first (and only) mapping end here (but anchor is not considered complete yet!)
obj2: *anchor # fails here saying that 'anchor' is unknown (very misleading!!)
```

```yaml
ref: &ref
  some: value
wrapper:
  # first mapping start here
  obj1: &anchor
    # second mapping start here
    <<: *ref # bug: still extra mapping start recorded here
    other: value
    # first mapping end here
  # second mapping end here (anchor is now complete)
obj2: *anchor # parsing exception here saying that a field name
              # was expected but a mapping start was received
              # It indeed replayed 2 mapping starts back to back!
```
</details>

The fix was fairly simple to apply once the issue was properly identified. *Identifying the issue, on the other hand... anyway* 😄
I've added a way to consume the next event without recording it, so the merge operator can drop the mapping start without it being recorded in case it was inside an anchor definition.
I made a unit test covering this.

<details>
<summary>Side note about the other commit</summary>
I've noticed a lot of redundancy in the unit tests when asserting the current token location. I made an helper method to refactor:

```java
TokenStreamLocation loc = jp.currentTokenLocation();
assertEquals(lineNr, loc.getLineNr());
assertEquals(columnNr, loc.getColumnNr());
assertEquals(charOffset, loc.getCharOffset());
assertEquals(byteOffset, loc.getByteOffset());
```
into:

```java
assertLocation(jp, lineNr, columnNr, charOffset, byteOffset);
```
It is isolated in another commit for easier review.
</details>

I am submitting this PR against the `3.1` base branch instead of the main `3.x` branch because I think this is just a minor patch, 3.1.1. Feel free to correct me if it needs to be rebased against the `3.x` base branch for the next 3.2 release.

Thank you