### PR TITLE
Fix #623: Add support for YAML 1.2 core schema

### DIFF
--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactory.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactory.java
@@ -49,6 +49,12 @@ public class YAMLFactory
     protected final SpecVersion _version;
 
     /**
+     * YAML schema for underlying parser to follow, if specified.
+     * @since 3.2
+     */
+    protected final YAMLSchema _schema;
+
+    /**
      * Helper object used to determine whether property names, String values
      * must be quoted or not.
      */
@@ -98,6 +104,7 @@ public class YAMLFactory
         // 26-Jul-2013, tatu: Seems like we should force output as 1.1 but
         //  that adds version declaration which looks ugly...
         _version = null;
+        _schema  = null;
         _quotingChecker = StringQuotingChecker.Default.instance();
         _loadSettings = null;
         _dumpSettings = null;
@@ -107,6 +114,7 @@ public class YAMLFactory
     {
         super(src);
         _version = src._version;
+        _schema  = src._schema;
         _quotingChecker = src._quotingChecker;
         _loadSettings = src._loadSettings;
         _dumpSettings = src._dumpSettings;
@@ -121,6 +129,7 @@ public class YAMLFactory
     {
         super(b);
         _version = b.yamlVersionToWrite();
+        _schema  = b.yamlSchema();
         _quotingChecker = b.stringQuotingChecker();
         _loadSettings = b.loadSettings();
         _dumpSettings = b.dumpSettings();

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactory.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactory.java
@@ -4,7 +4,11 @@ import java.io.*;
 
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.LoadSettingsBuilder;
 import org.snakeyaml.engine.v2.common.SpecVersion;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
+import org.snakeyaml.engine.v2.schema.FailsafeSchema;
+import org.snakeyaml.engine.v2.schema.JsonSchema;
 
 import tools.jackson.core.*;
 import tools.jackson.core.base.TextualTSFactory;
@@ -131,7 +135,30 @@ public class YAMLFactory
         _version = b.yamlVersionToWrite();
         _schema  = b.yamlSchema();
         _quotingChecker = b.stringQuotingChecker();
-        _loadSettings = b.loadSettings();
+
+        if (b.loadSettings() == null) {
+            LoadSettingsBuilder builder = LoadSettings.builder();
+            if (_schema != null) {
+                switch (_schema) {
+                    case FAILSAFE:
+                        builder.setSchema(new FailsafeSchema());
+                        break;
+                    case JSON:
+                        builder.setSchema(new JsonSchema());
+                        break;
+                    case CORE:
+                        builder.setSchema(new CoreSchema());
+                        break;
+                    default:
+                        break;
+                }
+            }
+            _loadSettings = builder.build();
+        }
+        else {
+            _loadSettings = b.loadSettings();
+        }
+
         _dumpSettings = b.dumpSettings();
     }
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -9,11 +9,7 @@ import tools.jackson.dataformat.yaml.util.StringQuotingChecker;
 
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.api.LoadSettingsBuilder;
 import org.snakeyaml.engine.v2.common.SpecVersion;
-import org.snakeyaml.engine.v2.schema.CoreSchema;
-import org.snakeyaml.engine.v2.schema.JsonSchema;
-import org.snakeyaml.engine.v2.schema.FailsafeSchema;
 
 /**
  * {@link tools.jackson.core.TSFBuilder}
@@ -314,25 +310,6 @@ public class YAMLFactoryBuilder
      * @return the {@code SnakeYAML} configuration to use when parsing YAML
      */
     public LoadSettings loadSettings() {
-        if (_loadSettings == null) {
-            LoadSettingsBuilder builder = LoadSettings.builder();
-            if (_schema != null) {
-                switch (_schema) {
-                    case FAILSAFE:
-                        builder.setSchema(new FailsafeSchema());
-                        break;
-                    case JSON:
-                        builder.setSchema(new JsonSchema());
-                        break;
-                    case CORE:
-                        builder.setSchema(new CoreSchema());
-                        break;
-                    default:
-                        break;
-                }
-            }
-            return builder.build();
-        }
         return _loadSettings;
     }
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -102,6 +102,7 @@ public class YAMLFactoryBuilder
     public YAMLFactoryBuilder(YAMLFactory base) {
         super(base);
         _version = base._version;
+        _schema  = base._schema;
         _quotingChecker = base._quotingChecker;
         _loadSettings = base._loadSettings;
         _dumpSettings = base._dumpSettings;

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -330,7 +330,7 @@ public class YAMLFactoryBuilder
                         break;
                 }
             }
-            _loadSettings = builder.build();
+            return builder.build();
         }
         return _loadSettings;
     }

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -9,7 +9,11 @@ import tools.jackson.dataformat.yaml.util.StringQuotingChecker;
 
 import org.snakeyaml.engine.v2.api.DumpSettings;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.LoadSettingsBuilder;
 import org.snakeyaml.engine.v2.common.SpecVersion;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
+import org.snakeyaml.engine.v2.schema.JsonSchema;
+import org.snakeyaml.engine.v2.schema.FailsafeSchema;
 
 /**
  * {@link tools.jackson.core.TSFBuilder}
@@ -40,6 +44,16 @@ public class YAMLFactoryBuilder
      * </p>
      */
     protected SpecVersion _version;
+
+    /**
+     * YAML schema for underlying parser to follow, if specified;
+     * left as {@code null} for backwards compatibility (which means
+     * whatever default settings {@code SnakeYAML} deems best).
+     * <p>
+     *     Ignored if you provide your own {@code LoadSettings}.
+     * </p>
+     */
+    protected YAMLSchema _schema;
 
     /**
      * Configuration for underlying parser to follow, if specified;
@@ -201,6 +215,20 @@ public class YAMLFactoryBuilder
     }
 
     /**
+     * Method for specifying the YAML schema to use during parsing; if
+     * {@code null} passed, will let {@code SnakeYAML} use its default settings.
+     *
+     * @param schema YAML schema to use for parsing, if not-null;
+     *    {@code null} for default handling
+     *
+     * @return This builder instance, to allow chaining
+     */
+    public YAMLFactoryBuilder yamlSchema(YAMLSchema schema) {
+        _schema = schema;
+        return this;
+    }
+
+    /**
      * Configuration for underlying parser to follow, if specified;
      * left as {@code null} for backwards compatibility (which means
      * whatever default settings {@code SnakeYAML} deems best).
@@ -257,6 +285,10 @@ public class YAMLFactoryBuilder
         return _version;
     }
 
+    public YAMLSchema yamlSchema() {
+        return _schema;
+    }
+
     public StringQuotingChecker stringQuotingChecker() {
         if (_quotingChecker != null) {
             return _quotingChecker;
@@ -277,6 +309,25 @@ public class YAMLFactoryBuilder
      * @return the {@code SnakeYAML} configuration to use when parsing YAML
      */
     public LoadSettings loadSettings() {
+        if (_loadSettings == null) {
+            LoadSettingsBuilder builder = LoadSettings.builder();
+            if (_schema != null) {
+                switch (_schema) {
+                    case FAILSAFE:
+                        builder.setSchema(new FailsafeSchema());
+                        break;
+                    case JSON:
+                        builder.setSchema(new JsonSchema());
+                        break;
+                    case CORE:
+                        builder.setSchema(new CoreSchema());
+                        break;
+                    default:
+                        break;
+                }
+            }
+            _loadSettings = builder.build();
+        }
         return _loadSettings;
     }
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLFactoryBuilder.java
@@ -52,6 +52,8 @@ public class YAMLFactoryBuilder
      * <p>
      *     Ignored if you provide your own {@code LoadSettings}.
      * </p>
+     *
+     * @since 3.2
      */
     protected YAMLSchema _schema;
 
@@ -222,6 +224,8 @@ public class YAMLFactoryBuilder
      *    {@code null} for default handling
      *
      * @return This builder instance, to allow chaining
+     *
+     * @since 3.2
      */
     public YAMLFactoryBuilder yamlSchema(YAMLSchema schema) {
         _schema = schema;

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
@@ -617,7 +617,20 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(double d) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeScalar(String.valueOf(d), "double", STYLE_SCALAR);
+        if (Double.isNaN(d)) {
+            _writeScalar(".nan", "double", STYLE_PLAIN);
+        }
+        else if (Double.isInfinite(d)) {
+            if (d > 0.0) {
+                _writeScalar(".inf", "double", STYLE_PLAIN);
+            }
+            else {
+                _writeScalar("-.inf", "double", STYLE_PLAIN);
+            }
+        }
+        else {
+            _writeScalar(String.valueOf(d), "double", STYLE_SCALAR);
+        }
         return this;
     }
 
@@ -625,7 +638,20 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(float f) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
+        if (Float.isNaN(f)) {
+            _writeScalar(".nan", "float", STYLE_PLAIN);
+        }
+        else if (Float.isInfinite(f)) {
+            if (f > 0.0f) {
+                _writeScalar(".inf", "float", STYLE_PLAIN);
+            }
+            else {
+                _writeScalar("-.inf", "float", STYLE_PLAIN);
+            }
+        }
+        else {
+            _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
+        }
         return this;
     }
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
@@ -617,15 +617,20 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(double d) throws JacksonException
     {
         _verifyValueWrite("write number");
-        if (Double.isNaN(d)) {
-            _writeScalar(".nan", "double", STYLE_PLAIN);
-        }
-        else if (Double.isInfinite(d)) {
-            if (d > 0.0) {
-                _writeScalar(".inf", "double", STYLE_PLAIN);
+        if (isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
+            if (Double.isNaN(d)) {
+                _writeScalar(".nan", "double", STYLE_PLAIN);
+            }
+            else if (Double.isInfinite(d)) {
+                if (d > 0.0) {
+                    _writeScalar(".inf", "double", STYLE_PLAIN);
+                }
+                else {
+                    _writeScalar("-.inf", "double", STYLE_PLAIN);
+                }
             }
             else {
-                _writeScalar("-.inf", "double", STYLE_PLAIN);
+                _writeScalar(String.valueOf(d), "double", STYLE_SCALAR);
             }
         }
         else {
@@ -638,18 +643,23 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(float f) throws JacksonException
     {
         _verifyValueWrite("write number");
-        if (Float.isNaN(f)) {
-            _writeScalar(".nan", "float", STYLE_PLAIN);
-        }
-        else if (Float.isInfinite(f)) {
-            if (f > 0.0f) {
-                _writeScalar(".inf", "float", STYLE_PLAIN);
+        if (isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
+            if (Float.isNaN(f)) {
+                _writeScalar(".nan", "float", STYLE_PLAIN);
+            }
+            else if (Float.isInfinite(f)) {
+                if (f > 0.0f) {
+                    _writeScalar(".inf", "float", STYLE_PLAIN);
+                }
+                else {
+                    _writeScalar("-.inf", "float", STYLE_PLAIN);
+                }
             }
             else {
-                _writeScalar("-.inf", "float", STYLE_PLAIN);
+                _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
             }
         }
-        else {
+        else {  
             _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
         }
         return this;

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -616,6 +616,8 @@ public class YAMLParser extends ParserBase
             switch (ch) {
             case 'b': case 'B': // binary
                 return _decodeNumberIntBinary(value, i+1, len, _numberNegative);
+            case 'o':
+                return _decodeNumberIntOctal(value, i+1, len, _numberNegative);
             case 'x': case 'X': // hex
                 return _decodeNumberIntHex(value, i+1, len, _numberNegative);
             case '0': case '1': case '2': case '3': case '4':

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -3,6 +3,8 @@ package tools.jackson.dataformat.yaml;
 import java.io.*;
 import java.math.BigInteger;
 import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import tools.jackson.core.*;
 import tools.jackson.core.base.ParserBase;
@@ -124,6 +126,12 @@ public class YAMLParser extends ParserBase
      * is enabled).
      */
     protected boolean _emittingSyntheticEmptyObject;    
+
+    /**
+     * Patterns for matching YAML's notation for Infinity and NaN values.
+     */
+    protected final Pattern _patternInf = Pattern.compile("([-+]?)\\.(?:inf|Inf|INF)");
+    protected final Pattern _patternNaN = Pattern.compile("\\.(?:nan|NaN|NAN)");
 
     /*
     /**********************************************************************
@@ -1152,6 +1160,19 @@ public class YAMLParser extends ParserBase
 
     private JsonToken _cleanYamlFloat(String str)
     {
+        // Convert infinity strings to Java notation, preserving the sign if present
+        Matcher matcher = _patternInf.matcher(str);
+        if (matcher.matches()) {
+            _cleanedTextValue = matcher.group(1) + "Infinity";
+            return JsonToken.VALUE_NUMBER_FLOAT;
+        }
+
+        // Convert not-a-number (NaN) strings to Java notation
+        if (_patternNaN.matcher(str).matches()) {
+            _cleanedTextValue = "NaN";
+            return JsonToken.VALUE_NUMBER_FLOAT;
+        }
+
         // Here we do NOT yet know whether we might have underscores so check
         final int len = str.length();
         int ix = str.indexOf('_');

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -1160,17 +1160,18 @@ public class YAMLParser extends ParserBase
 
     private JsonToken _cleanYamlFloat(String str)
     {
-        // Convert infinity strings to Java notation, preserving the sign if present
         Matcher matcher = _patternInf.matcher(str);
         if (matcher.matches()) {
-            _cleanedTextValue = matcher.group(1) + "Infinity";
-            return JsonToken.VALUE_NUMBER_FLOAT;
+            if (matcher.group(1).equals("-")) {
+                return resetAsNaN(str, Double.NEGATIVE_INFINITY);
+            }
+            else {
+                return resetAsNaN(str, Double.POSITIVE_INFINITY);
+            }
         }
 
-        // Convert not-a-number (NaN) strings to Java notation
         if (_patternNaN.matcher(str).matches()) {
-            _cleanedTextValue = "NaN";
-            return JsonToken.VALUE_NUMBER_FLOAT;
+            return resetAsNaN(str, Double.NaN);
         }
 
         // Here we do NOT yet know whether we might have underscores so check

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -24,7 +24,6 @@ import org.snakeyaml.engine.v2.events.ScalarEvent;
 import org.snakeyaml.engine.v2.exceptions.Mark;
 import org.snakeyaml.engine.v2.nodes.Tag;
 import org.snakeyaml.engine.v2.parser.ParserImpl;
-import org.snakeyaml.engine.v2.resolver.JsonScalarResolver;
 import org.snakeyaml.engine.v2.resolver.ScalarResolver;
 import org.snakeyaml.engine.v2.scanner.StreamReader;
 
@@ -59,7 +58,7 @@ public class YAMLParser extends ParserBase
     protected final Reader _reader;
 
     protected final ParserImpl _yamlParser;
-    protected final ScalarResolver _yamlResolver = new JsonScalarResolver();
+    protected final ScalarResolver _yamlResolver;
 
     /*
     /**********************************************************************
@@ -136,31 +135,19 @@ public class YAMLParser extends ParserBase
             int streamReadFeatures, int formatFeatures,
             LoadSettings loadSettings, Reader reader)
     {
-        this(readCtxt, ioCtxt, br, streamReadFeatures, formatFeatures,
-                        reader,
-                        _defaultParserImpl(loadSettings, reader));
-    }
-    
-    protected YAMLParser(ObjectReadContext readCtxt, IOContext ioCtxt, BufferRecycler br,
-            int streamReadFeatures, int formatFeatures,
-            Reader reader,
-            ParserImpl yamlParser)
-    {
         super(readCtxt, ioCtxt, streamReadFeatures);
+        if (loadSettings == null) {
+            loadSettings = LoadSettings.builder().build();
+        }
         _formatFeatures = formatFeatures;
         _reader = reader;
-        _yamlParser = yamlParser;
+        _yamlParser = new ParserImpl(loadSettings, new StreamReader(loadSettings, reader));
+        _yamlResolver = loadSettings.getSchema().getScalarResolver();
+
         _cfgEmptyStringsToNull = YAMLReadFeature.EMPTY_STRING_AS_NULL.enabledIn(formatFeatures);
         DupDetector dups = StreamReadFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamReadFeatures)
                 ? DupDetector.rootDetector(this) : null;
         _streamReadContext = SimpleStreamReadContext.createRootContext(dups);
-    }
-
-    private static ParserImpl _defaultParserImpl(LoadSettings settings, Reader r) {
-        if (settings == null) {
-            settings = LoadSettings.builder().build();
-        }
-        return new ParserImpl(settings, new StreamReader(settings, r));
     }
 
     /*

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -130,8 +130,8 @@ public class YAMLParser extends ParserBase
     /**
      * Patterns for matching YAML's notation for Infinity and NaN values.
      */
-    protected final Pattern _patternInf = Pattern.compile("([-+]?)\\.(?:inf|Inf|INF)");
-    protected final Pattern _patternNaN = Pattern.compile("\\.(?:nan|NaN|NAN)");
+    protected final static Pattern _patternInf = Pattern.compile("([-+]?)\\.(?:inf|Inf|INF)");
+    protected final static Pattern _patternNaN = Pattern.compile("\\.(?:nan|NaN|NAN)");
 
     /*
     /**********************************************************************

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLSchema.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLSchema.java
@@ -1,0 +1,23 @@
+package tools.jackson.dataformat.yaml;
+
+/**
+ * Enum of YAML 1.2 schemas that can be used for parsing YAML documents.
+ */
+public enum YAMLSchema {
+    /**
+     * Schema guaranteed to work with any document.
+     * @see https://yaml.org/spec/1.2.2/#101-failsafe-schema
+     */
+    FAILSAFE,
+    /**
+     * Schema for parsing JSON-compatible YAML documents.
+     * @see https://yaml.org/spec/1.2.2/#102-json-schema
+     */
+    JSON,
+    /**
+     * Schema for parsing standard YAML documents.
+     * @see https://yaml.org/spec/1.2.2/#103-core-schema
+     */
+    CORE,
+    ;
+}

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLSchema.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLSchema.java
@@ -2,6 +2,8 @@ package tools.jackson.dataformat.yaml;
 
 /**
  * Enum of YAML 1.2 schemas that can be used for parsing YAML documents.
+ *
+ * @since 3.2
  */
 public enum YAMLSchema {
     /**

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLWriteFeature.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLWriteFeature.java
@@ -146,12 +146,12 @@ public enum YAMLWriteFeature implements FormatFeature
      * emitted using YAML notation ({@code .inf}, {@code -.inf}, {@code .nan})
      * or Java notation ({@code Infinity}, {@code -Infinity}, {@code NaN}).
      * <p>
-     *     Default value is {@code false} for backwards compatibility.
-     * </p>
-     * <p>
-     * Feature is disabled by default.
+     * Feature is enabled by default. Disable it for backwards compatibility
+     * (pre-3.2 behavior).
+     *
+     * @since 3.2
      */
-    USE_YAML_NONFINITE_NOTATION(false),
+    USE_YAML_NONFINITE_NOTATION(true),
     ;
 
     private final boolean _defaultState;

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLWriteFeature.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLWriteFeature.java
@@ -140,6 +140,18 @@ public enum YAMLWriteFeature implements FormatFeature
      * Feature is disabled by default.
      */
     ALLOW_LONG_KEYS(false),
+
+    /**
+     * Whether non-finite float values (infinities and not-a-number) should be
+     * emitted using YAML notation ({@code .inf}, {@code -.inf}, {@code .nan})
+     * or Java notation ({@code Infinity}, {@code -Infinity}, {@code NaN}).
+     * <p>
+     *     Default value is {@code false} for backwards compatibility.
+     * </p>
+     * <p>
+     * Feature is disabled by default.
+     */
+    USE_YAML_NONFINITE_NOTATION(false),
     ;
 
     private final boolean _defaultState;

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchema623Test.java
@@ -3,18 +3,16 @@ package tools.jackson.dataformat.yaml.deser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.schema.CoreSchema;
 
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLSchema;
 
 // Tests deserialization of YAML 1.2 core schema.
 public class YAML12CoreSchema623Test extends ModuleTestBase {
-    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
-    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
-    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+    private final YAMLFactory FACTORY = YAMLFactory.builder().yamlSchema(YAMLSchema.CORE).build();
+    private final YAMLMapper  MAPPER  = YAMLMapper.builder(FACTORY).build();
 
     @Test
     public void testNull() throws Exception

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchema623Test.java
@@ -1,0 +1,102 @@
+package tools.jackson.dataformat.yaml.deser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
+
+import tools.jackson.dataformat.yaml.ModuleTestBase;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+// Tests deserialization of YAML 1.2 core schema.
+public class YAML12CoreSchema623Test extends ModuleTestBase {
+    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
+    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
+    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+
+    @Test
+    public void testNull() throws Exception
+    {
+        Object o = MAPPER.readValue("null", Object.class);
+        assertEquals(null, o);
+
+        o = MAPPER.readValue("~", Object.class);
+        assertEquals(null, o);
+    }
+
+    @Test
+    public void testBoolean() throws Exception
+    {
+        Boolean b = MAPPER.readValue("true", Boolean.class);
+        assertEquals(Boolean.TRUE, b);
+
+        b = MAPPER.readValue("false", Boolean.class);
+        assertEquals(Boolean.FALSE, b);
+
+        b = MAPPER.readValue("True", Boolean.class);
+        assertEquals(Boolean.TRUE, b);
+
+        b = MAPPER.readValue("False", Boolean.class);
+        assertEquals(Boolean.FALSE, b);
+
+        b = MAPPER.readValue("TRUE", Boolean.class);
+        assertEquals(Boolean.TRUE, b);
+
+        b = MAPPER.readValue("FALSE", Boolean.class);
+        assertEquals(Boolean.FALSE, b);
+    }
+
+    @Test
+    public void testNaN() throws Exception
+    {
+        Float f = MAPPER.readValue(".nan", Float.class);
+        assertEquals(Float.valueOf(Float.NaN), f);
+
+        Double d = MAPPER.readValue(".NaN", Double.class);
+        assertEquals(Double.valueOf(Double.NaN), d);
+
+        Number n = MAPPER.readValue(".NAN", Number.class);
+        assertEquals(Double.valueOf(Double.NaN), n);
+    }
+
+    @Test
+    public void testInfinity() throws Exception
+    {
+        Float f = MAPPER.readValue(".inf", Float.class);
+        assertEquals(Float.valueOf(Float.POSITIVE_INFINITY), f);
+
+        Double d = MAPPER.readValue("-.Inf", Double.class);
+        assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), d);
+
+        Number n = MAPPER.readValue("+.INF", Number.class);
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), n);
+    }
+
+    @Test
+    public void testOctal() throws Exception
+    {
+        Integer i = MAPPER.readValue("0o10", Integer.class);
+        assertEquals(Integer.valueOf(8), i);
+
+        Long l = MAPPER.readValue("0o20", Long.class);
+        assertEquals(Long.valueOf(16), l);
+
+        Number n = MAPPER.readValue("0o30", Number.class);
+        assertEquals(Integer.valueOf(24), n);
+    }
+
+    @Test
+    public void testHexadecimal() throws Exception
+    {
+        Integer i = MAPPER.readValue("0x10", Integer.class);
+        assertEquals(Integer.valueOf(16), i);
+
+        Long l = MAPPER.readValue("0x20", Long.class);
+        assertEquals(Long.valueOf(32), l);
+
+        Number n = MAPPER.readValue("0x30", Number.class);
+        assertEquals(Integer.valueOf(48), n);
+    }
+}

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
@@ -63,6 +63,14 @@ public class YAML12CoreSchemaParseTest extends ModuleTestBase {
         - .NAN
         strings:
         - hello, world!
+        - Infinity
+        - NaN
+        - 'null'
+        - 'false'
+        - '0'
+        - '-1.0'
+        - '0o644'
+        - '0xFF'
         """;
 
         YAMLParser p = (YAMLParser) MAPPER.createParser(YAML);
@@ -156,6 +164,22 @@ public class YAML12CoreSchemaParseTest extends ModuleTestBase {
         assertToken(JsonToken.START_ARRAY, p.nextToken());
         assertToken(JsonToken.VALUE_STRING, p.nextToken());
         assertEquals("hello, world!", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("Infinity", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("NaN", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("null", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("false", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("0", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("-1.0", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("0o644", p.getString());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("0xFF", p.getString());
         assertToken(JsonToken.END_ARRAY, p.nextToken());
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
@@ -1,0 +1,165 @@
+package tools.jackson.dataformat.yaml.deser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
+
+import tools.jackson.core.JsonToken;
+import tools.jackson.dataformat.yaml.ModuleTestBase;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLParser;
+import tools.jackson.dataformat.yaml.YAMLReadFeature;
+
+/**
+ * Test YAML parsing when using the YAML 1.2 core schema (i.e. CoreScalarResolver).
+ */
+public class YAML12CoreSchemaParseTest extends ModuleTestBase {
+    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
+    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).enable(YAMLReadFeature.EMPTY_STRING_AS_NULL).build();
+    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+
+    @Test
+    public void testTokens() throws Exception {
+        final String YAML = """
+        ---
+        nulls:
+        - null
+        - Null
+        - NULL
+        - ~
+        - # empty
+        booleans:
+        - true
+        - True
+        - TRUE
+        - false
+        - False
+        - FALSE
+        integers:
+        - 0
+        - 42
+        - -1
+        - 0o755
+        - 0xDEADBEEF
+        floats:
+        - 0.0
+        - 3.14159
+        - 2.998e8
+        - 1.0e-10
+        infinities:
+        - .inf
+        - .Inf
+        - .INF
+        - +.inf
+        - +.Inf
+        - +.INF
+        - -.inf
+        - -.Inf
+        - -.INF
+        nans:
+        - .nan
+        - .NaN
+        - .NAN
+        strings:
+        - hello, world!
+        """;
+
+        YAMLParser p = (YAMLParser) MAPPER.createParser(YAML);
+        assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("nulls", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NULL,  p.nextToken());
+        assertToken(JsonToken.VALUE_NULL,  p.nextToken());
+        assertToken(JsonToken.VALUE_NULL,  p.nextToken());
+        assertToken(JsonToken.VALUE_NULL,  p.nextToken());
+        assertToken(JsonToken.VALUE_NULL,  p.nextToken());
+        assertToken(JsonToken.END_ARRAY,   p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("booleans", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_TRUE,  p.nextToken());
+        assertToken(JsonToken.VALUE_TRUE,  p.nextToken());
+        assertToken(JsonToken.VALUE_TRUE,  p.nextToken());
+        assertToken(JsonToken.VALUE_FALSE, p.nextToken());
+        assertToken(JsonToken.VALUE_FALSE, p.nextToken());
+        assertToken(JsonToken.VALUE_FALSE, p.nextToken());
+        assertToken(JsonToken.END_ARRAY,   p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("integers", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(0, p.getIntValue());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(42, p.getIntValue());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(-1, p.getIntValue());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(493, p.getIntValue());
+        assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+        assertEquals(3735928559L, p.getLongValue());
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("floats", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(0.0, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(3.14159, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(2.998e8, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(1.0e-10, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("infinities", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NEGATIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NEGATIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NEGATIVE_INFINITY, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("nans", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NaN, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NaN, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+        assertEquals(Double.NaN, p.getDoubleValue(), 0.0);
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+        assertEquals("strings", p.currentName());
+        assertToken(JsonToken.START_ARRAY, p.nextToken());
+        assertToken(JsonToken.VALUE_STRING, p.nextToken());
+        assertEquals("hello, world!", p.getString());
+        assertToken(JsonToken.END_ARRAY, p.nextToken());
+
+        assertToken(JsonToken.END_OBJECT, p.nextToken());
+    }
+}

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/YAML12CoreSchemaParseTest.java
@@ -3,8 +3,6 @@ package tools.jackson.dataformat.yaml.deser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.schema.CoreSchema;
 
 import tools.jackson.core.JsonToken;
 import tools.jackson.dataformat.yaml.ModuleTestBase;
@@ -12,14 +10,14 @@ import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 import tools.jackson.dataformat.yaml.YAMLParser;
 import tools.jackson.dataformat.yaml.YAMLReadFeature;
+import tools.jackson.dataformat.yaml.YAMLSchema;
 
 /**
  * Test YAML parsing when using the YAML 1.2 core schema (i.e. CoreScalarResolver).
  */
 public class YAML12CoreSchemaParseTest extends ModuleTestBase {
-    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
-    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).enable(YAMLReadFeature.EMPTY_STRING_AS_NULL).build();
-    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+    private final YAMLFactory FACTORY = YAMLFactory.builder().yamlSchema(YAMLSchema.CORE).enable(YAMLReadFeature.EMPTY_STRING_AS_NULL).build();
+    private final YAMLMapper  MAPPER  = YAMLMapper.builder(FACTORY).build();
 
     @Test
     public void testTokens() throws Exception {

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
@@ -13,12 +13,11 @@ import org.snakeyaml.engine.v2.schema.CoreSchema;
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
-import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 // Tests serialization of YAML 1.2 core schema.
 public class YAML12CoreSchema623Test extends ModuleTestBase {
     private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
-    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).enable(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION).build();
+    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
     private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
 
     @Test

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
@@ -7,18 +7,16 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.snakeyaml.engine.v2.api.LoadSettings;
-import org.snakeyaml.engine.v2.schema.CoreSchema;
 
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLSchema;
 
 // Tests serialization of YAML 1.2 core schema.
 public class YAML12CoreSchema623Test extends ModuleTestBase {
-    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
-    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
-    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+    private final YAMLFactory FACTORY = YAMLFactory.builder().yamlSchema(YAMLSchema.CORE).build();
+    private final YAMLMapper  MAPPER  = YAMLMapper.builder(FACTORY).build();
 
     @Test
     public void testNull() throws Exception

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
@@ -13,11 +13,12 @@ import org.snakeyaml.engine.v2.schema.CoreSchema;
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 // Tests serialization of YAML 1.2 core schema.
 public class YAML12CoreSchema623Test extends ModuleTestBase {
     private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
-    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
+    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).enable(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION).build();
     private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
 
     @Test

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAML12CoreSchema623Test.java
@@ -1,0 +1,76 @@
+package tools.jackson.dataformat.yaml.ser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
+
+import tools.jackson.dataformat.yaml.ModuleTestBase;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+// Tests serialization of YAML 1.2 core schema.
+public class YAML12CoreSchema623Test extends ModuleTestBase {
+    private final LoadSettings SETTINGS = LoadSettings.builder().setSchema(new CoreSchema()).build();
+    private final YAMLFactory  FACTORY  = YAMLFactory.builder().loadSettings(SETTINGS).build();
+    private final YAMLMapper   MAPPER   = YAMLMapper.builder(FACTORY).build();
+
+    @Test
+    public void testNull() throws Exception
+    {
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", null);
+        String doc = MAPPER.writeValueAsString(map);
+        doc = trimDocMarker(doc);
+        assertEquals("key: null", doc);
+    }
+
+    @Test
+    public void testBoolean() throws Exception
+    {
+        List<Boolean> list = List.of(true, false);
+        String doc = MAPPER.writeValueAsString(list);
+        doc = trimDocMarker(doc);
+        String expected =
+            "- true\n" +
+            "- false";
+        assertEquals(expected, doc);
+    }
+
+    @Test
+    public void testNaN() throws Exception
+    {
+        List<Number> list = List.of(Float.NaN, Double.NaN);
+        String doc = MAPPER.writeValueAsString(list);
+        doc = trimDocMarker(doc);
+        String expected =
+            "- .nan\n" +
+            "- .nan";
+        assertEquals(expected, doc);
+    }
+
+    @Test
+    public void testInfinity() throws Exception
+    {
+        List<Number> list = List.of(
+            Float.POSITIVE_INFINITY,
+            Float.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY);
+
+        String doc = MAPPER.writeValueAsString(list);
+        doc = trimDocMarker(doc);
+
+        String expected =
+            "- .inf\n"  +
+            "- -.inf\n" +
+            "- .inf\n"  +
+            "- -.inf";
+        assertEquals(expected, doc);
+    }
+}


### PR DESCRIPTION
Add support for reading/writing [YAML 1.2 core schema](https://yaml.org/spec/1.2.2/#core-schema). Implements #623.

- Use CoreScalarResolver when CoreSchema is specified via LoadSettings.
- Map YAML string notation for infinity and non-a-number (`.inf` and `.nan`) to Java notation (`Infinity` and `NaN`).
- Serialize infinity and NaN values as `.inf` and `.nan`, respectively.
- Add handling for octal integers prefixed with `0o`.
- Added tests for deserializing from/serializing to YAML 1.2 core schema.