### PR TITLE
Fix #368: Allow skipping csv rows with only empty values (line of commas)

### DIFF
--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
@@ -162,6 +162,20 @@ public enum CsvReadFeature
      * @since 3.1
      */
     ONLY_UNQUOTED_NULL_VALUES_AS_NULL(false),
+
+    /**
+     * Feature that allows skipping input rows that consist solely of column separator
+     * characters (for example, a line containing only {@code ,,} with the default
+     * comma separator).
+     * This is different from {@link #SKIP_EMPTY_LINES} which only skips lines that are
+     * completely empty or blank (whitespace only): this feature skips lines that
+     * contain only consecutive separator characters followed by a linefeed.
+     *<p>
+     * Feature is disabled by default.
+     *
+     * @since 3.2
+     */
+    SKIP_EMPTY_ROWS(false),
     ;
 
     private final boolean _defaultState;

--- a/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -76,6 +76,18 @@ public class CsvDecoder
 
     protected boolean _skipBlankLines;
 
+    protected boolean _skipEmptyRows;
+
+    /**
+     * Number of separator characters consumed by {@link #_trySkipEmptyRow()} when
+     * a row starting with separators turns out to contain non-empty values.
+     * These consumed separators are replayed as empty String values by
+     * {@link #nextString()}.
+     *
+     * @since 3.2
+     */
+    protected int _pendingEmptyColumns;
+
     /**
      * Maximum of quote character, linefeeds (\r and \n), escape character.
      */
@@ -299,6 +311,7 @@ public class CsvDecoder
         _allowComments = CsvReadFeature.ALLOW_COMMENTS.enabledIn(csvFeatures);
         _trimSpaces = CsvReadFeature.TRIM_SPACES.enabledIn(csvFeatures);
         _skipBlankLines = CsvReadFeature.SKIP_EMPTY_LINES.enabledIn(csvFeatures);
+        _skipEmptyRows = CsvReadFeature.SKIP_EMPTY_ROWS.enabledIn(csvFeatures);
         _trimSpaces = CsvReadFeature.TRIM_SPACES.enabledIn(csvFeatures);
         _inputBuffer = ctxt.allocTokenBuffer();
         _bufferRecyclable = true; // since we allocated it
@@ -532,11 +545,11 @@ public class CsvDecoder
         if (_allowComments) {
             return _skipCommentLines();
         }
-        if (!_skipBlankLines) {
+        if (!_skipBlankLines && !_skipEmptyRows) {
             return hasMoreInput();
         }
 
-        // only need to skip fully empty lines
+        // only need to skip fully empty lines (and optionally empty rows)
         while (hasMoreInput()) {
             char ch = _inputBuffer[_inputPtr];
             if (ch == '\r' || ch == '\n') {
@@ -545,10 +558,17 @@ public class CsvDecoder
                 _handleLF();
                 continue;
             }
-            if (ch != ' ') {
-                return true; // processing can go on
+            if (ch == ' ' && _skipBlankLines) {
+                ++_inputPtr;
+                continue;
             }
-            ++_inputPtr;
+            // [dataformats-text#368]: Row of only separator characters?
+            if (_skipEmptyRows && ch == _separatorChar) {
+                if (_trySkipEmptyRow()) {
+                    continue;
+                }
+            }
+            return true; // processing can go on
         }
         return false; // end of input
     }
@@ -573,6 +593,12 @@ public class CsvDecoder
                 ++_inputPtr;
                 continue;
             default:
+                // [dataformats-text#368]: Check if line consists only of separators
+                if (_skipEmptyRows && ch == _separatorChar) {
+                    if (_trySkipEmptyRow()) {
+                        continue;
+                    }
+                }
                 return true;
             }
         }
@@ -588,6 +614,53 @@ public class CsvDecoder
                 _handleLF();
                 break;
             }
+        }
+    }
+
+    /**
+     * Helper method called when we see a separator character at the start of a line
+     * and need to determine if the entire row consists only of consecutive separator
+     * characters (no other content) followed by a linefeed or EOF.
+     *<p>
+     * Consumes separator characters one at a time. If a linefeed or EOF is reached,
+     * the row is empty and is skipped (returns {@code true}). If any other character
+     * is found, the consumed separators are recorded in {@link #_pendingEmptyColumns}
+     * so that {@link #nextString()} can replay them as empty values.
+     *
+     * @return {@code true} if the row was determined to be empty and was skipped;
+     *   {@code false} if the row contains non-empty content (consumed separators
+     *   will be replayed via {@link #_pendingEmptyColumns})
+     */
+    private boolean _trySkipEmptyRow() throws JacksonException
+    {
+        int separatorCount = 0;
+        while (true) {
+            // Consume the separator character at current position
+            ++_inputPtr;
+            ++separatorCount;
+
+            // Need more input?
+            if (_inputPtr >= _inputEnd) {
+                if (!loadMore()) {
+                    // EOF after separators only: empty row at end of input
+                    return true;
+                }
+            }
+            char ch = _inputBuffer[_inputPtr];
+            if (ch == _separatorChar) {
+                continue;
+            }
+            if (ch == '\r' || ch == '\n') {
+                // Row consisted only of separators: skip it
+                ++_inputPtr;
+                _pendingLF = ch;
+                _handleLF();
+                return true;
+            }
+            // Found non-separator content: not an empty row.
+            // Record consumed separators so nextString() replays them.
+            _pendingEmptyColumns = separatorCount;
+            return false;
         }
     }
 
@@ -626,6 +699,14 @@ public class CsvDecoder
     public String nextString() throws JacksonException {
         _numTypesValid = NR_UNKNOWN;
         _currInputQuoted = false;  // Reset; set to true below only if opening quote found
+
+        // [dataformats-text#368]: Replay separator characters consumed by _trySkipEmptyRow()
+        // as empty column values
+        if (_pendingEmptyColumns > 0) {
+            --_pendingEmptyColumns;
+            _textBuffer.resetWithString("");
+            return "";
+        }
 
         if (_pendingLF > 0) { // either pendingLF, or closed
             if (_inputReader != null) { // if closed, we just need to return null

--- a/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -312,7 +312,6 @@ public class CsvDecoder
         _trimSpaces = CsvReadFeature.TRIM_SPACES.enabledIn(csvFeatures);
         _skipBlankLines = CsvReadFeature.SKIP_EMPTY_LINES.enabledIn(csvFeatures);
         _skipEmptyRows = CsvReadFeature.SKIP_EMPTY_ROWS.enabledIn(csvFeatures);
-        _trimSpaces = CsvReadFeature.TRIM_SPACES.enabledIn(csvFeatures);
         _inputBuffer = ctxt.allocTokenBuffer();
         _bufferRecyclable = true; // since we allocated it
         _tokenInputRow = -1;
@@ -525,6 +524,7 @@ public class CsvDecoder
      * @return True if there is a new data line to handle; false if not
      */
     public boolean startNewLine() throws JacksonException {
+        _pendingEmptyColumns = 0;
         // first: if pending LF, skip it
         if (_pendingLF != 0) {
             if (_inputReader == null) {

--- a/csv/src/test/java/tools/jackson/dataformat/csv/deser/SkipEmptyRows368Test.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/deser/SkipEmptyRows368Test.java
@@ -1,0 +1,221 @@
+package tools.jackson.dataformat.csv.deser;
+
+import java.io.FilterReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import tools.jackson.databind.MappingIterator;
+
+import tools.jackson.dataformat.csv.*;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// for [dataformats-text#368]: Skip CSV rows with only empty values (commas only)
+public class SkipEmptyRows368Test extends ModuleTestBase
+{
+    @JsonPropertyOrder({ "id", "color", "shape" })
+    protected static class Entry {
+        public String id;
+        public String color;
+        public String shape;
+    }
+
+    // Basic case: row with only commas should be skipped
+    @Test
+    public void testSkipRowsWithOnlyCommas() throws Exception
+    {
+        final String CSV = "ID,Color,Shape\n"
+                + "1,red,circle\n"
+                + ",,\n"
+                + "2,blue,square\n";
+
+        CsvMapper mapper = mapperForCsv();
+        CsvSchema schema = mapper.schemaFor(Entry.class).withHeader();
+        MappingIterator<Entry> it = mapper.readerFor(Entry.class)
+                .with(schema)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValues(CSV);
+
+        assertTrue(it.hasNext());
+        Entry first = it.next();
+        assertEquals("1", first.id);
+        assertEquals("red", first.color);
+        assertEquals("circle", first.shape);
+
+        assertTrue(it.hasNext());
+        Entry second = it.next();
+        assertEquals("2", second.id);
+        assertEquals("blue", second.color);
+        assertEquals("square", second.shape);
+
+        // Should only have 2 entries, the comma-only row should be skipped
+        assertEquals(false, it.hasNext());
+        it.close();
+    }
+
+    // Array mode: row with only commas should be skipped
+    @Test
+    public void testSkipRowsWithOnlyCommasArrayMode() throws Exception
+    {
+        final String CSV = "1,red,circle\n"
+                + ",,\n"
+                + "2,blue,square\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertArrayEquals(new String[][] {
+                {"1", "red", "circle"},
+                {"2", "blue", "square"}
+        }, rows);
+    }
+
+    // Verify feature is disabled by default (comma-only rows are NOT skipped)
+    @Test
+    public void testEmptyRowsNotSkippedByDefault() throws Exception
+    {
+        final String CSV = "1,red\n,,\n2,blue\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .readValue(CSV);
+
+        assertEquals(3, rows.length);
+        assertArrayEquals(new String[]{"1", "red"}, rows[0]);
+        assertArrayEquals(new String[]{"", "", ""}, rows[1]);
+        assertArrayEquals(new String[]{"2", "blue"}, rows[2]);
+    }
+
+    // Commas with spaces are NOT considered empty rows (only consecutive separators qualify)
+    @Test
+    public void testRowsWithCommasAndSpacesNotSkipped() throws Exception
+    {
+        final String CSV = "1,red\n , , \n2,blue\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertEquals(3, rows.length);
+    }
+
+    // Multiple consecutive empty rows
+    @Test
+    public void testSkipMultipleEmptyRows() throws Exception
+    {
+        final String CSV = "1,red\n,,\n,,\n2,blue\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertArrayEquals(new String[][] {
+                {"1", "red"},
+                {"2", "blue"}
+        }, rows);
+    }
+
+    // Trailing empty row
+    @Test
+    public void testSkipTrailingEmptyRow() throws Exception
+    {
+        final String CSV = "1,red\n2,blue\n,,\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertArrayEquals(new String[][] {
+                {"1", "red"},
+                {"2", "blue"}
+        }, rows);
+    }
+
+    // Leading empty row
+    @Test
+    public void testSkipLeadingEmptyRow() throws Exception
+    {
+        final String CSV = ",,\n1,red\n2,blue\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertArrayEquals(new String[][] {
+                {"1", "red"},
+                {"2", "blue"}
+        }, rows);
+    }
+
+    // Test that an empty row at a buffer boundary is correctly handled.
+    // Uses a Reader that delivers data in tiny chunks to force buffer refills
+    // within the empty row.
+    @Test
+    public void testEmptyRowAtBufferBoundary() throws Exception
+    {
+        final String CSV = "1,red\n,,\n2,blue\n";
+
+        // Use a Reader that returns only 7 chars at a time ("1,red\n," then ",\n2,bl" etc.)
+        // This forces the decoder's buffer to refill mid-row.
+        StringReader base = new StringReader(CSV);
+        FilterReader throttled = new FilterReader(base) {
+            @Override
+            public int read(char[] cbuf, int off, int len) throws IOException {
+                return super.read(cbuf, off, Math.min(len, 7));
+            }
+        };
+
+        CsvMapper mapper = mapperForCsv();
+        MappingIterator<String[]> it = mapper
+                .readerFor(String[].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValues(throttled);
+
+        assertTrue(it.hasNext());
+        assertArrayEquals(new String[]{"1", "red"}, it.next());
+
+        assertTrue(it.hasNext());
+        assertArrayEquals(new String[]{"2", "blue"}, it.next());
+
+        assertEquals(false, it.hasNext());
+        it.close();
+    }
+
+    // Verify that a row starting with commas but containing real content is NOT skipped
+    @Test
+    public void testRowWithLeadingCommasNotSkipped() throws Exception
+    {
+        final String CSV = "1,red\n,,hello\n2,blue\n";
+
+        String[][] rows = mapperForCsv()
+                .readerFor(String[][].class)
+                .with(CsvReadFeature.WRAP_AS_ARRAY)
+                .with(CsvReadFeature.SKIP_EMPTY_ROWS)
+                .readValue(CSV);
+
+        assertArrayEquals(new String[][] {
+                {"1", "red"},
+                {"", "", "hello"},
+                {"2", "blue"}
+        }, rows);
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -16,18 +16,18 @@ implementations)
 
 3.2.0 (not yet released)
 
-#9: Incorrect detection of `hasNextValue()` for simple iteration with `String[]`
+#9: (csv) Incorrect detection of `hasNextValue()` for simple iteration with `String[]`
  (fix by @cowtowncoder, w/ Claude code)
-#22: YAML anchors don't seem to work with `@JsonCreator`
+#22: (yaml) YAML anchors don't seem to work with `@JsonCreator`
  (reported by Rye G)
  (fix by @cowtowncoder, w/ Claude code)
-#368: Allow skipping csv rows with only empty values (line of commas)
+#368: (csv) Allow skipping csv rows with only empty values (line of commas)
  (requested by @GitXm123)
  (fix by @cowtowncoder, w/ Claude code)
-#623: Add support for YAML 1.2 non-finite (Infinite, -Infinite, NaN)
+#623: (yaml) Add support for YAML 1.2 non-finite (Infinite, -Infinite, NaN)
   numbers, Octal notation
  (contributed by Michael C)
-#631: Add `CsvFactory.builder().maxQuoteCheckChars()` for configuring
+#631: (csv) Add `CsvFactory.builder().maxQuoteCheckChars()` for configuring
   heuristic quoting check
  (fix by @cowtowncoder, w/ Claude code)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -21,6 +21,9 @@ implementations)
 #22: YAML anchors don't seem to work with `@JsonCreator`
  (reported by Rye G)
  (fix by @cowtowncoder, w/ Claude code)
+#368: Allow skipping csv rows with only empty values (line of commas)
+ (requested by @GitXm123)
+ (fix by @cowtowncoder, w/ Claude code)
 #623: Add support for YAML 1.2 non-finite (Infinite, -Infinite, NaN)
   numbers, Octal notation
  (contributed by Michael C)


### PR DESCRIPTION
Adds `CsvReadFeature.SKIP_EMPTY_ROWS`.