### PR TITLE
Implement #355: allow skipping/mapping as absent empty columns

### DIFF
--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvParser.java
@@ -157,6 +157,11 @@ public class CsvParser
      */
     protected final boolean _cfgOnlyUnquotedNullValuesAsNull;
 
+    /**
+     * @since 3.2
+     */
+    protected final boolean _cfgEmptyStringAsMissing;
+
     /*
     /**********************************************************************
     /* State
@@ -258,6 +263,7 @@ public class CsvParser
         _cfgEmptyStringAsNull = CsvReadFeature.EMPTY_STRING_AS_NULL.enabledIn(csvFeatures);
         _cfgEmptyUnquotedStringAsNull = CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL.enabledIn(csvFeatures);
         _cfgOnlyUnquotedNullValuesAsNull = CsvReadFeature.ONLY_UNQUOTED_NULL_VALUES_AS_NULL.enabledIn(csvFeatures);
+        _cfgEmptyStringAsMissing = CsvReadFeature.EMPTY_STRING_AS_MISSING.enabledIn(csvFeatures);
     }
 
     /*
@@ -333,6 +339,7 @@ public class CsvParser
         _cfgEmptyStringAsNull = CsvReadFeature.EMPTY_STRING_AS_NULL.enabledIn(_formatFeatures);
         _cfgEmptyUnquotedStringAsNull = CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL.enabledIn(_formatFeatures);
         _cfgOnlyUnquotedNullValuesAsNull = CsvReadFeature.ONLY_UNQUOTED_NULL_VALUES_AS_NULL.enabledIn(_formatFeatures);
+        _cfgEmptyStringAsMissing = CsvReadFeature.EMPTY_STRING_AS_MISSING.enabledIn(_formatFeatures);
         return this;
     }
 
@@ -342,6 +349,7 @@ public class CsvParser
         _cfgEmptyStringAsNull = CsvReadFeature.EMPTY_STRING_AS_NULL.enabledIn(_formatFeatures);
         _cfgEmptyUnquotedStringAsNull = CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL.enabledIn(_formatFeatures);
         _cfgOnlyUnquotedNullValuesAsNull = CsvReadFeature.ONLY_UNQUOTED_NULL_VALUES_AS_NULL.enabledIn(_formatFeatures);
+        _cfgEmptyStringAsMissing = CsvReadFeature.EMPTY_STRING_AS_MISSING.enabledIn(_formatFeatures);
         return this;
     }
 
@@ -746,24 +754,36 @@ public class CsvParser
         // NOTE: only called when we do have real Schema
         String next;
 
-        try {
-            next = _reader.nextString();
-        } catch (RuntimeException e) {
-            // 12-Oct-2015, tatu: Need to resync here as well...
-            _state = STATE_SKIP_EXTRA_COLUMNS;
-            throw e;
-        }
-
-        if (next == null) { // end of record or input...
-            // 16-Mar-2017, tatu: [dataformat-csv#137] Missing column(s)?
-            if (_columnIndex < _columnCount) {
-                return _handleMissingColumns();
+        // [dataformats-text#355]: loop to skip empty unquoted values when
+        // EMPTY_STRING_AS_MISSING enabled (avoids recursion for consecutive empty cells)
+        while (true) {
+            try {
+                next = _reader.nextString();
+            } catch (RuntimeException e) {
+                // 12-Oct-2015, tatu: Need to resync here as well...
+                _state = STATE_SKIP_EXTRA_COLUMNS;
+                throw e;
             }
-            return _handleObjectRowEnd();
-        }
-        if (_columnIndex >= _columnCount) {
-            _currentValue = next;
-            return _handleExtraColumn(next);
+
+            if (next == null) { // end of record or input...
+                // 16-Mar-2017, tatu: [dataformat-csv#137] Missing column(s)?
+                if (_columnIndex < _columnCount) {
+                    return _handleMissingColumns();
+                }
+                return _handleObjectRowEnd();
+            }
+            if (_columnIndex >= _columnCount) {
+                _currentValue = next;
+                return _handleExtraColumn(next);
+            }
+            // [dataformats-text#355]: skip empty unquoted values when EMPTY_STRING_AS_MISSING enabled
+            if (_cfgEmptyStringAsMissing
+                    && next.isEmpty()
+                    && !_reader.isCurrentTokenQuoted()) {
+                ++_columnIndex;
+                continue;
+            }
+            break;
         }
         final CsvSchema.Column column = _schema.column(_columnIndex);
         _state = STATE_NAMED_VALUE;

--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvParser.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvParser.java
@@ -263,7 +263,7 @@ public class CsvParser
         _cfgEmptyStringAsNull = CsvReadFeature.EMPTY_STRING_AS_NULL.enabledIn(csvFeatures);
         _cfgEmptyUnquotedStringAsNull = CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL.enabledIn(csvFeatures);
         _cfgOnlyUnquotedNullValuesAsNull = CsvReadFeature.ONLY_UNQUOTED_NULL_VALUES_AS_NULL.enabledIn(csvFeatures);
-        _cfgEmptyStringAsMissing = CsvReadFeature.EMPTY_STRING_AS_MISSING.enabledIn(csvFeatures);
+        _cfgEmptyStringAsMissing = CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING.enabledIn(csvFeatures);
     }
 
     /*

--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
@@ -164,6 +164,26 @@ public enum CsvReadFeature
     ONLY_UNQUOTED_NULL_VALUES_AS_NULL(false),
 
     /**
+     * Feature that enables treating empty unquoted cell values as "missing",
+     * effectively suppressing the token pair (property name + value) for such cells.
+     * This means that if the target POJO field has a default value, it will be
+     * preserved instead of being overwritten with an empty String.
+     *<p>
+     * This is different from {@link #EMPTY_STRING_AS_NULL} which coerces the value
+     * to {@code null}: this feature causes the value to not be included in the token
+     * stream at all, similar to how truly missing columns (row shorter than schema)
+     * are handled.
+     *<p>
+     * Only applies to unquoted empty values; a quoted empty string ({@code ""}) is
+     * still reported normally.
+     *<p>
+     * Feature is disabled by default for backwards compatibility.
+     *
+     * @since 3.2
+     */
+    EMPTY_STRING_AS_MISSING(false),
+
+    /**
      * Feature that allows skipping input rows that consist solely of column separator
      * characters (for example, a line containing only {@code ,,} with the default
      * comma separator).

--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvReadFeature.java
@@ -122,7 +122,8 @@ public enum CsvReadFeature
     INSERT_NULLS_FOR_MISSING_COLUMNS(false),
 
     /**
-     * Feature that enables coercing an empty {@link String} to `null`.
+     * Feature that enables coercing an empty {@link String} (quoted or unquoted)
+     * to {@code null}.
      *<p>
      * Note that if this setting is enabled, {@link #EMPTY_UNQUOTED_STRING_AS_NULL}
      * has no effect.
@@ -132,7 +133,7 @@ public enum CsvReadFeature
     EMPTY_STRING_AS_NULL(false),
 
     /**
-     * Feature that enables coercing an empty un-quoted {@link String} to `null`.
+     * Feature that enables coercing an empty un-quoted {@link String} to {@code null}.
      * This feature allow differentiating between an empty quoted {@link String} and an empty un-quoted {@link String}.
      *<p>
      * Note that this feature is only considered if
@@ -142,6 +143,26 @@ public enum CsvReadFeature
      * Feature is disabled by default for backwards compatibility.
      */
     EMPTY_UNQUOTED_STRING_AS_NULL(false),
+
+    /**
+     * Feature that enables treating empty unquoted cell values as "missing",
+     * effectively suppressing the token pair (property name + value) for such cells.
+     * This means that if the target POJO field has a default value, it will be
+     * preserved instead of being overwritten with an empty String.
+     *<p>
+     * This is different from {@link #EMPTY_STRING_AS_NULL} which coerces the value
+     * to {@code null}: this feature causes the value to not be included in the token
+     * stream at all, similar to how truly missing columns (row shorter than schema)
+     * are handled.
+     *<p>
+     * Only applies to unquoted empty values; a quoted empty string ({@code ""}) is
+     * still reported normally.
+     *<p>
+     * Feature is disabled by default for backwards compatibility.
+     *
+     * @since 3.2
+     */
+    EMPTY_UNQUOTED_STRING_AS_MISSING(false),
 
     /**
      * Feature that enables treating only un-quoted values matching the configured
@@ -162,26 +183,6 @@ public enum CsvReadFeature
      * @since 3.1
      */
     ONLY_UNQUOTED_NULL_VALUES_AS_NULL(false),
-
-    /**
-     * Feature that enables treating empty unquoted cell values as "missing",
-     * effectively suppressing the token pair (property name + value) for such cells.
-     * This means that if the target POJO field has a default value, it will be
-     * preserved instead of being overwritten with an empty String.
-     *<p>
-     * This is different from {@link #EMPTY_STRING_AS_NULL} which coerces the value
-     * to {@code null}: this feature causes the value to not be included in the token
-     * stream at all, similar to how truly missing columns (row shorter than schema)
-     * are handled.
-     *<p>
-     * Only applies to unquoted empty values; a quoted empty string ({@code ""}) is
-     * still reported normally.
-     *<p>
-     * Feature is disabled by default for backwards compatibility.
-     *
-     * @since 3.2
-     */
-    EMPTY_STRING_AS_MISSING(false),
 
     /**
      * Feature that allows skipping input rows that consist solely of column separator

--- a/csv/src/test/java/tools/jackson/dataformat/csv/deser/EmptyStringAsMissingTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/deser/EmptyStringAsMissingTest.java
@@ -1,0 +1,153 @@
+package tools.jackson.dataformat.csv.deser;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.dataformat.csv.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link CsvReadFeature#EMPTY_STRING_AS_MISSING}
+ * (see {@code dataformats-text#355}).
+ */
+public class EmptyStringAsMissingTest
+    extends ModuleTestBase
+{
+    @JsonPropertyOrder({"id", "value"})
+    static class PojoWithDefault {
+        public Integer id;
+        public String value = "default";
+    }
+
+    @JsonPropertyOrder({"firstName", "middleName", "lastName"})
+    static class ThreeFields {
+        public String firstName;
+        public String middleName = "M";
+        public String lastName;
+    }
+
+    /*
+    /**********************************************************
+    /* Test methods
+    /**********************************************************
+     */
+
+    private final CsvMapper MAPPER = mapperForCsv();
+
+    // [dataformats-text#355]: empty cell in present column should use POJO default
+    @Test
+    public void testEmptyCellUsesPOJODefault() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        // Empty cell with trailing comma
+        PojoWithDefault result = r.readValue("id,value\n1,");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("default", result.value);
+    }
+
+    // Missing column (no header) should still use defaults regardless of feature
+    @Test
+    public void testMissingColumnStillUsesDefault() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        PojoWithDefault result = r.readValue("id\n1");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("default", result.value);
+    }
+
+    // Quoted empty string should NOT be treated as missing
+    @Test
+    public void testQuotedEmptyStringNotMissing() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        PojoWithDefault result = r.readValue("id,value\n1,\"\"");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("", result.value);
+    }
+
+    // Non-empty values should be unaffected
+    @Test
+    public void testNonEmptyValuesUnaffected() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        PojoWithDefault result = r.readValue("id,value\n1,hello");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("hello", result.value);
+    }
+
+    // Empty cell in the middle of a row should be skipped, surrounding values OK
+    @Test
+    public void testEmptyMiddleCellSkipped() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(ThreeFields.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        ThreeFields result = r.readValue("firstName,middleName,lastName\nGrace,,Hopper");
+        assertEquals("Grace", result.firstName);
+        assertEquals("M", result.middleName);
+        assertEquals("Hopper", result.lastName);
+    }
+
+    // Feature disabled: empty cell should produce empty string (backwards compat)
+    @Test
+    public void testFeatureDisabledGivesEmptyString() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema);
+
+        PojoWithDefault result = r.readValue("id,value\n1,");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("", result.value);
+    }
+
+    // Using fixed schema (not header-based)
+    @Test
+    public void testWithFixedSchema() throws Exception
+    {
+        CsvSchema schema = MAPPER.schemaFor(PojoWithDefault.class);
+        ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        PojoWithDefault result = r.readValue("1,");
+        assertEquals(Integer.valueOf(1), result.id);
+        assertEquals("default", result.value);
+    }
+
+    // All columns empty: all should use POJO defaults (tests loop, not recursion)
+    @Test
+    public void testAllColumnsEmpty() throws Exception
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withHeader();
+        ObjectReader r = MAPPER.readerFor(ThreeFields.class)
+                .with(schema)
+                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+
+        ThreeFields result = r.readValue("firstName,middleName,lastName\n,,");
+        assertNull(result.firstName);
+        assertEquals("M", result.middleName);
+        assertNull(result.lastName);
+    }
+}

--- a/csv/src/test/java/tools/jackson/dataformat/csv/deser/EmptyStringAsMissingTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/deser/EmptyStringAsMissingTest.java
@@ -10,7 +10,7 @@ import tools.jackson.dataformat.csv.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for {@link CsvReadFeature#EMPTY_STRING_AS_MISSING}
+ * Tests for {@link CsvReadFeature#EMPTY_UNQUOTED_STRING_AS_MISSING}
  * (see {@code dataformats-text#355}).
  */
 public class EmptyStringAsMissingTest
@@ -44,7 +44,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         // Empty cell with trailing comma
         PojoWithDefault result = r.readValue("id,value\n1,");
@@ -59,7 +59,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         PojoWithDefault result = r.readValue("id\n1");
         assertEquals(Integer.valueOf(1), result.id);
@@ -73,7 +73,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         PojoWithDefault result = r.readValue("id,value\n1,\"\"");
         assertEquals(Integer.valueOf(1), result.id);
@@ -87,7 +87,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         PojoWithDefault result = r.readValue("id,value\n1,hello");
         assertEquals(Integer.valueOf(1), result.id);
@@ -101,7 +101,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(ThreeFields.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         ThreeFields result = r.readValue("firstName,middleName,lastName\nGrace,,Hopper");
         assertEquals("Grace", result.firstName);
@@ -129,7 +129,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = MAPPER.schemaFor(PojoWithDefault.class);
         ObjectReader r = MAPPER.readerFor(PojoWithDefault.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         PojoWithDefault result = r.readValue("1,");
         assertEquals(Integer.valueOf(1), result.id);
@@ -143,7 +143,7 @@ public class EmptyStringAsMissingTest
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
         ObjectReader r = MAPPER.readerFor(ThreeFields.class)
                 .with(schema)
-                .with(CsvReadFeature.EMPTY_STRING_AS_MISSING);
+                .with(CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING);
 
         ThreeFields result = r.readValue("firstName,middleName,lastName\n,,");
         assertNull(result.firstName);

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,7 +22,7 @@ implementations)
  (reported by Rye G)
  (fix by @cowtowncoder, w/ Claude code)
 #355: (csv) Allow mapping empty cells (columns) as "absent" properties (i.e. skip)
-  by `CsvReadFeature.EMPTY_STRING_AS_MISSING`
+  by `CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_MISSING`
  (requested by @hosswald)
  (fix by @cowtowncoder, w/ Claude code)
 #368: (csv) Allow skipping csv rows with only empty values (line of commas)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -21,6 +21,10 @@ implementations)
 #22: (yaml) YAML anchors don't seem to work with `@JsonCreator`
  (reported by Rye G)
  (fix by @cowtowncoder, w/ Claude code)
+#355: (csv) Allow mapping empty cells (columns) as "absent" properties (i.e. skip)
+  by `CsvReadFeature.EMPTY_STRING_AS_MISSING`
+ (requested by @hosswald)
+ (fix by @cowtowncoder, w/ Claude code)
 #368: (csv) Allow skipping csv rows with only empty values (line of commas)
  (requested by @GitXm123)
  (fix by @cowtowncoder, w/ Claude code)


### PR DESCRIPTION
Adds `CsvReadFeature.EMPTY_STRING_AS_MISSING`, handling, tests.
