### PR TITLE
Modernize TOML corpus compliance tests

### DIFF
--- a/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,7 +20,7 @@ public class ComplianceInvalidTest extends TomlMapperTestBase
     @MethodSource("data")
     public void tomlTestInvalidCorpus(Path path) {
         assumeTrue(path != null, "Set -Dtoml.corpus.dir=/path/to/toml-test to run TOML corpus tests");
-        assertThrows(StreamReadException.class, () -> MAPPER.readTree(path.toFile()));
+        assertThrows(TomlStreamReadException.class, () -> MAPPER.readTree(path.toFile()));
     }
 
     public static Stream<Arguments> data() throws Exception {

--- a/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
@@ -1,49 +1,35 @@
 package tools.jackson.dataformat.toml;
 
-import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ComplianceInvalidTest extends TomlMapperTestBase
 {
-    private final ObjectMapper MAPPER = newTomlMapper();
+    private static final ObjectMapper MAPPER = newTomlMapper();
 
-    private final Path path;
-
-    public ComplianceInvalidTest(Path path) {
-        this.path = path;
-    }
-
-    // JUnit 5 throws error when methodSource provides empty `Stream` which
-    // seems to always be the case....
-    @Disabled
-    @MethodSource("data")
     @ParameterizedTest
-    public void test(Path path) throws IOException {
-        // Test implementation
-        assertThrows(
-                TomlStreamReadException.class,
-                () -> MAPPER.readTree(path.toFile())
-        );
+    @MethodSource("data")
+    public void tomlTestInvalidCorpus(Path path) {
+        assumeTrue(path != null, "Set -Dtoml.corpus.dir=/path/to/toml-test to run TOML corpus tests");
+        assertThrows(StreamReadException.class, () -> MAPPER.readTree(path.toFile()));
     }
 
-    // This is the static method that provides data for the parameterized test
-    public static Stream<Object[]> data() throws IOException {
-        Path folder = Paths.get("compliance", "invalid");
-        if (!Files.exists(folder)) {
-            return Stream.empty();  // Ensure this folder exists with files for the test to run
+    public static Stream<Arguments> data() throws Exception {
+        Path corpusRoot = ComplianceValidTest.corpusRoot();
+        if (corpusRoot == null) {
+            return Stream.of(Arguments.of((Path) null));
         }
-        return Files.walk(folder)
-                .filter(Files::isRegularFile)
-                .map(p -> new Object[]{p});
+        return ComplianceValidTest.corpusFiles(corpusRoot, "invalid/").stream()
+                .map(Arguments::of);
     }
-
 }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceValidTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceValidTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import tools.jackson.core.JacksonException;
 import tools.jackson.core.io.NumberInput;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -78,7 +77,7 @@ public class ComplianceValidTest extends TomlMapperTestBase
         return toml.resolveSibling(fileName.substring(0, fileName.length() - 5) + ".json");
     }
 
-    private static JsonNode mapFromComplianceNode(JsonNode expected) throws JacksonException {
+    private static JsonNode mapFromComplianceNode(JsonNode expected) {
         final JsonNodeCreator nodeF = JsonMapper.shared().createObjectNode();
         if (expected.isObject()) {
             ObjectNode expectedObject = (ObjectNode) expected;
@@ -141,13 +140,20 @@ public class ComplianceValidTest extends TomlMapperTestBase
 
     private static boolean semanticallyEquals(JsonNode expected, JsonNode actual) {
         if (expected.isNumber() && actual.isNumber()) {
-            double expectedDouble = expected.doubleValue();
-            double actualDouble = actual.doubleValue();
-            if (!Double.isFinite(expectedDouble) || !Double.isFinite(actualDouble)) {
-                return Double.compare(expectedDouble, actualDouble) == 0;
-            }
+            // Compare integrals via BigInteger first: doubleValue() on a large
+            // BigInteger/BigDecimal overflows to Infinity, which would otherwise
+            // make two distinct large values compare equal via the non-finite path.
             if (expected.isIntegralNumber() && actual.isIntegralNumber()) {
                 return toBigInteger(expected).equals(toBigInteger(actual));
+            }
+            // Only Float/Double nodes can hold NaN/±Infinity.
+            if (expected.isFloat() || expected.isDouble()
+                    || actual.isFloat() || actual.isDouble()) {
+                double e = expected.doubleValue();
+                double a = actual.doubleValue();
+                if (!Double.isFinite(e) || !Double.isFinite(a)) {
+                    return Double.compare(e, a) == 0;
+                }
             }
             return toBigDecimal(expected).compareTo(toBigDecimal(actual)) == 0;
         }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceValidTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceValidTest.java
@@ -1,123 +1,196 @@
 package tools.jackson.dataformat.toml;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.file.*;
 import java.time.*;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.io.NumberInput;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeCreator;
 import tools.jackson.databind.node.ObjectNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ComplianceValidTest extends TomlMapperTestBase
 {
-    public static Stream<Object[]> data() throws IOException {
-        Path folder = Paths.get("compliance", "valid");
-        if (!Files.exists(folder)) {
-            return Stream.empty();
-        }
-        return Files.walk(folder)
-                .filter(Files::isRegularFile)
-                .filter(p -> p.toString().endsWith(".toml"))
-                .map(p -> {
-                    String path = p.toString();
-                    String withoutSuffix = path.substring(0, path.length() - 5);
-                    Path json = Paths.get(withoutSuffix + ".json");
-                    if (Files.isRegularFile(json)) {
-                        return new Object[]{p, JsonMapper.shared().readTree(json)};
-                    }
-                    // can't parse inf values :(
-                    /*
-                    Path yaml = Paths.get(withoutSuffix + ".yaml");
-                    if (Files.isRegularFile(yaml)) {
-                        return new Object[]{p, YAMLMapper.shared().readTree(yaml)};
-                    }
-                    */
-                    return null;
-                })
-                .filter(Objects::nonNull);
-    }
+    private static final ObjectMapper TOML_MAPPER = TomlMapper.builder()
+            .enable(TomlReadFeature.PARSE_JAVA_TIME)
+            .build();
+    private static final ObjectMapper JSON_MAPPER = JsonMapper.shared();
 
-    private final Path path;
-    private final ObjectNode expected;
-
-    public ComplianceValidTest(Path path, ObjectNode expected) {
-        this.path = path;
-        this.expected = expected;
-    }
-
-    // JUnit 5 throws error when methodSource provides empty `Stream` which
-    // seems to always be the case....
-    @Disabled
-    @MethodSource("data")
     @ParameterizedTest
-    public void test() throws Exception {
-        JsonNode actual = TomlMapper.builder()
-                .enable(TomlReadFeature.PARSE_JAVA_TIME)
-                .build().readTree(path.toFile());
-        assertEquals(mapFromComplianceNode(expected), actual);
+    @MethodSource("data")
+    public void tomlTestValidCorpus(Path toml, Path json) throws Exception {
+        assumeTrue(toml != null, "Set -Dtoml.corpus.dir=/path/to/toml-test to run TOML corpus tests");
+
+        JsonNode expected = mapFromComplianceNode(JSON_MAPPER.readTree(json.toFile()));
+        JsonNode actual = TOML_MAPPER.readTree(toml.toFile());
+        assertTrue(semanticallyEquals(expected, actual),
+                "expected=" + expected + " actual=" + actual);
     }
 
-    private static JsonNode mapFromComplianceNode(ObjectNode expected) {
-        final JsonNodeCreator nodeF = expected;
-        if (expected.has("type") && expected.has("value")) {
-            JsonNode value = expected.get("value");
-            switch (expected.get("type").stringValue()) {
-                case "string":
-                    // for some reason, the compliance tests escape these values. this makes some tests fail right now
-                    return nodeF.stringNode(value.stringValue());
-                case "integer":
-                    return nodeF.numberNode(NumberInput.parseBigInteger(value.stringValue(), false));
-                case "float":
-                    switch (value.stringValue()) {
-                        case "inf":
-                            return nodeF.numberNode(Double.POSITIVE_INFINITY);
-                        case "-inf":
-                            return nodeF.numberNode(Double.NEGATIVE_INFINITY);
-                        case "nan":
-                            return nodeF.numberNode(Double.NaN);
-                        default:
-                            return nodeF.numberNode(NumberInput.parseBigDecimal(value.stringValue(), false));
-                    }
-                case "boolean":
-                    return nodeF.booleanNode(Boolean.parseBoolean(value.stringValue()));
-                case "offset datetime":
-                    return nodeF.pojoNode(OffsetDateTime.parse(value.stringValue()));
-                case "local datetime":
-                case "datetime-local":
-                    return nodeF.pojoNode(LocalDateTime.parse(value.stringValue()));
-                case "local date":
-                case "date":
-                    return nodeF.pojoNode(LocalDate.parse(value.stringValue()));
-                case "local time":
-                case "time":
-                    return nodeF.pojoNode(LocalTime.parse(value.stringValue()));
-                case "array":
-                    ArrayNode array = nodeF.arrayNode();
-                    for (JsonNode member : value) {
-                        array.add(mapFromComplianceNode((ObjectNode) member));
-                    }
-                    return array;
-                default:
-                    throw new AssertionError(expected);
+    public static Stream<Arguments> data() throws Exception {
+        Path corpusRoot = corpusRoot();
+        if (corpusRoot == null) {
+            return Stream.of(Arguments.of(null, null));
+        }
+        return corpusFiles(corpusRoot, "valid/").stream()
+                .map(toml -> Arguments.of(toml, expectedJson(toml)))
+                .filter(args -> Files.isRegularFile((Path) args.get()[1]));
+    }
+
+    static Path corpusRoot() {
+        String root = System.getProperty("toml.corpus.dir");
+        if (root == null || root.isBlank()) {
+            return null;
+        }
+        return Paths.get(root);
+    }
+
+    static List<Path> corpusFiles(Path corpusRoot, String prefix) throws IOException {
+        Path testsRoot = corpusRoot.resolve("tests");
+        Path fileList = testsRoot.resolve(System.getProperty("toml.corpus.fileList", "files-toml-1.0.0"));
+        List<Path> files = new ArrayList<>();
+        for (String line : Files.readAllLines(fileList)) {
+            if (line.isBlank() || line.startsWith("#") || !line.endsWith(".toml") || !line.startsWith(prefix)) {
+                continue;
             }
-        } else {
-            ObjectNode object = expected.objectNode();
-            for (Map.Entry<String, JsonNode> field : expected.properties()) {
-                object.set(field.getKey(), mapFromComplianceNode((ObjectNode) field.getValue()));
+            files.add(testsRoot.resolve(line));
+        }
+        return files;
+    }
+
+    private static Path expectedJson(Path toml) {
+        String fileName = toml.getFileName().toString();
+        return toml.resolveSibling(fileName.substring(0, fileName.length() - 5) + ".json");
+    }
+
+    private static JsonNode mapFromComplianceNode(JsonNode expected) throws JacksonException {
+        final JsonNodeCreator nodeF = JsonMapper.shared().createObjectNode();
+        if (expected.isObject()) {
+            ObjectNode expectedObject = (ObjectNode) expected;
+            if (expectedObject.has("type") && expectedObject.has("value")) {
+                JsonNode value = expectedObject.get("value");
+                switch (expectedObject.get("type").stringValue()) {
+                    case "string":
+                        return nodeF.stringNode(value.stringValue());
+                    case "integer":
+                        return nodeF.numberNode(NumberInput.parseBigInteger(value.stringValue(), false));
+                    case "float":
+                        switch (value.stringValue()) {
+                            case "inf":
+                                return nodeF.numberNode(Double.POSITIVE_INFINITY);
+                            case "-inf":
+                                return nodeF.numberNode(Double.NEGATIVE_INFINITY);
+                            case "nan":
+                                return nodeF.numberNode(Double.NaN);
+                            default:
+                                return nodeF.numberNode(NumberInput.parseBigDecimal(value.stringValue(), false));
+                        }
+                    case "bool":
+                    case "boolean":
+                        return nodeF.booleanNode(Boolean.parseBoolean(value.stringValue()));
+                    case "datetime":
+                    case "offset datetime":
+                        return nodeF.pojoNode(OffsetDateTime.parse(value.stringValue()));
+                    case "datetime-local":
+                    case "local datetime":
+                        return nodeF.pojoNode(LocalDateTime.parse(value.stringValue()));
+                    case "date":
+                    case "date-local":
+                    case "local date":
+                        return nodeF.pojoNode(LocalDate.parse(value.stringValue()));
+                    case "time":
+                    case "time-local":
+                    case "local time":
+                        return nodeF.pojoNode(LocalTime.parse(value.stringValue()));
+                    case "array":
+                        return mapFromComplianceNode(value);
+                    default:
+                        throw new AssertionError(expectedObject);
+                }
+            }
+            ObjectNode object = expectedObject.objectNode();
+            for (Map.Entry<String, JsonNode> field : expectedObject.properties()) {
+                object.set(field.getKey(), mapFromComplianceNode(field.getValue()));
             }
             return object;
         }
+        if (expected.isArray()) {
+            ArrayNode array = JsonMapper.shared().createArrayNode();
+            for (JsonNode member : expected) {
+                array.add(mapFromComplianceNode(member));
+            }
+            return array;
+        }
+        throw new AssertionError(expected);
+    }
+
+    private static boolean semanticallyEquals(JsonNode expected, JsonNode actual) {
+        if (expected.isNumber() && actual.isNumber()) {
+            double expectedDouble = expected.doubleValue();
+            double actualDouble = actual.doubleValue();
+            if (!Double.isFinite(expectedDouble) || !Double.isFinite(actualDouble)) {
+                return Double.compare(expectedDouble, actualDouble) == 0;
+            }
+            if (expected.isIntegralNumber() && actual.isIntegralNumber()) {
+                return toBigInteger(expected).equals(toBigInteger(actual));
+            }
+            return toBigDecimal(expected).compareTo(toBigDecimal(actual)) == 0;
+        }
+        if (expected.isObject() && actual.isObject()) {
+            if (expected.size() != actual.size()) {
+                return false;
+            }
+            for (String name : expected.propertyNames()) {
+                JsonNode actualValue = actual.get(name);
+                if (actualValue == null || !semanticallyEquals(expected.get(name), actualValue)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (expected.isArray() && actual.isArray()) {
+            if (expected.size() != actual.size()) {
+                return false;
+            }
+            for (int i = 0; i < expected.size(); i++) {
+                if (!semanticallyEquals(expected.get(i), actual.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return expected.equals(actual);
+    }
+
+    private static BigInteger toBigInteger(JsonNode node) {
+        if (node.isBigInteger()) {
+            return node.bigIntegerValue();
+        }
+        return BigInteger.valueOf(node.longValue());
+    }
+
+    private static BigDecimal toBigDecimal(JsonNode node) {
+        if (node.isBigDecimal()) {
+            return node.decimalValue();
+        }
+        if (node.isIntegralNumber()) {
+            return new BigDecimal(toBigInteger(node));
+        }
+        return BigDecimal.valueOf(node.doubleValue());
     }
 }


### PR DESCRIPTION
Modernizes the TOML compliance test harness so it can be run against a local checkout of the official `toml-lang/toml-test` corpus.

Changes:
- Reads `tests/files-toml-1.0.0` from `-Dtoml.corpus.dir=/path/to/toml-test`.
- Keeps normal builds opt-in by assumption-skipping when the corpus path is absent.
- Restores parameterized per-fixture reporting for both valid and invalid corpus tests.
- Adds semantic comparison for typed corpus JSON values, including object order, numeric node classes, arrays, and non-finite floats.

This PR is the base for the stacked TOML corpus compliance fixes.