### PR TITLE
Fix TOML int64 boundary parsing

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -78,6 +78,8 @@ implementations)
   add `CsvReadFeature.CASE_INSENSITIVE_HEADERS`
  (reported by Tomas H)
  (fix by @cowtowncoder, w/ Claude code)
+#672: (toml) Fix TOML int64 boundary parsing
+  (fix by @yawkat)
 
 3.1.3 (01-May-2026)
 3.1.2 (11-Apr-2026)

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -336,8 +336,15 @@ class TomlParser {
             return factory.numberNode(v);
         }
         if (length <= 18 || NumberInput.inLongRange(buffer, start, length, negative)) {
-            long v = NumberInput.parseLong(buffer, start, length);
-            if (negative) v = -v;
+            long v;
+            if (length <= 18) {
+                v = NumberInput.parseLong(buffer, start, length);
+                if (negative) {
+                    v = -v;
+                }
+            } else {
+                v = NumberInput.parseLong19(buffer, start, negative);
+            }
             // Might still fit in int, need to check
             if ((int) v == v) {
                 return factory.numberNode((int) v);

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -388,6 +388,17 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void integerLongBoundaries() throws Exception {
+        assertEquals(
+                JsonNodeFactory.instance.objectNode()
+                        .put("max", Long.MAX_VALUE)
+                        .put("min", Long.MIN_VALUE),
+                toml("max = 9223372036854775807\n" +
+                        "min = -9223372036854775808")
+        );
+    }
+
+    @Test
     public void floats() throws Exception {
         ObjectNode json = json("{\"flt1\": 1.0, \"flt2\": 3.1415, \"flt3\": -0.01, \"flt4\": 5.0e22, \"flt5\": 1e06, \"flt6\": -2e-2, \"flt7\": 6.626e-34}");
         ObjectNode toml = toml("# fractional\n" +


### PR DESCRIPTION
Fixes TOML decimal integer parsing for 19-digit signed int64 boundary values.

Changes:
- Uses `NumberInput.parseLong19(...)` for 19-digit values after long-range validation.
- Adds regression coverage for `Long.MAX_VALUE` and `Long.MIN_VALUE`.

Resolves #663