### PR TITLE
Handle TOML byte order marks

### DIFF
--- a/toml/src/main/java/tools/jackson/dataformat/toml/StringOutputUtil.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/StringOutputUtil.java
@@ -62,6 +62,12 @@ class StringOutputUtil {
             return 0;
         }
 
+        // BOM is only permitted at the start of input. When writing it as content,
+        // force a basic string so it can be escaped instead of emitted literally.
+        if (c == 0xFEFF) {
+            return BASIC_STRING;
+        }
+
         // first, get the very restrictive unquoted keys out of the way.
         // unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
         if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
@@ -118,6 +124,9 @@ class StringOutputUtil {
                 return("\\\"");
             case '\\':
                 return("\\\\");
+            // Keep BOM escaped inside strings; a literal BOM is only valid at document start.
+            case '\uFEFF':
+                return("\\uFEFF");
             default:
                 if (c < 0x10) {
                     return "\\u000" + Integer.toHexString(c);

--- a/toml/src/main/jflex/tools/jackson/dataformat/toml/toml.jflex
+++ b/toml/src/main/jflex/tools/jackson/dataformat/toml/toml.jflex
@@ -124,7 +124,7 @@ Ws = [ \t]*
 WsNonEmpty = [ \t]+
 NewLine = \n|\r\n
 CommentStartSymbol = "#"
-NonEol = [^\u0000-\u0008\u000a-\u001f\u007f]
+NonEol = [^\u0000-\u0008\u000a-\u001f\u007f\uFEFF]
 
 //Expression = {Ws} (({KeyVal}|{Table}) {Ws}) {Comment}?
 Comment = {CommentStartSymbol} {NonEol}*
@@ -240,6 +240,12 @@ HexDig = [0-9A-Fa-f]
 
 <EXPECT_EXPRESSION> {
     // this state matches until the *first* simple-key of a key, or until the -open token of a table.
+
+    \uFEFF {
+          if (yychar != 0) {
+              throw errorContext.atPosition(this).generic("Byte order mark is only permitted at the start of a document");
+          }
+      }
 
     // toml = expression *( newline expression )
     // expression =  ws [ comment ]
@@ -433,7 +439,7 @@ HexDig = [0-9A-Fa-f]
 }
 
 <BASIC_STRING, ML_BASIC_STRING> {
-    [^\u0000-\u0008\u000a-\u001f\u007f\\\"]+ { appendNormalTextToken(); }
+    [^\u0000-\u0008\u000a-\u001f\u007f\uFEFF\\\"]+ { appendNormalTextToken(); }
     \\\" { textBuffer.append('"'); }
     \\\\ { textBuffer.append('\\'); }
     \\b { textBuffer.append('\b'); }
@@ -449,7 +455,7 @@ HexDig = [0-9A-Fa-f]
 <LITERAL_STRING> {
     // literal-string = apostrophe *literal-char apostrophe
     {Apostrophe} {return TomlToken.STRING;}
-    [^\u0000-\u0008\u000a-\u001f\u007f']+ { appendNormalTextToken(); }
+    [^\u0000-\u0008\u000a-\u001f\u007f\uFEFF']+ { appendNormalTextToken(); }
 }
 
 <ML_LITERAL_STRING> {
@@ -457,7 +463,7 @@ HexDig = [0-9A-Fa-f]
     // ml-literal-body = *mll-content *( mll-quotes 1*mll-content ) [ mll-quotes ]
     // mll-quotes = 1*2apostrophe
     {MlLiteralStringDelim} {return TomlToken.STRING;}
-    [^\u0000-\u0008\u000a-\u001f\u007f']+ { appendNormalTextToken(); }
+    [^\u0000-\u0008\u000a-\u001f\u007f\uFEFF']+ { appendNormalTextToken(); }
     {NewLine} { appendNewlineWithPossibleTrim(); }
     // mll-quotes: inline
     {Apostrophe} { textBuffer.append('\''); }
@@ -479,6 +485,9 @@ HexDig = [0-9A-Fa-f]
 }
 [\u0000-\u001f\u007f] {
   throw errorContext.atPosition(this).generic("Illegal control character");
+}
+\uFEFF {
+  throw errorContext.atPosition(this).generic("Byte order mark is only permitted at the start of a document");
 }
 \# {
   throw errorContext.atPosition(this).generic("Comment not permitted here");

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -953,6 +953,21 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void byteOrderMarkOnlyAtDocumentStart() throws Exception {
+        assertEquals(json("{\"key\": \"value\"}"), toml("\uFEFFkey = \"value\""));
+
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("key = \"value\"\n\uFEFFother = true")
+        );
+        assertTrue(thrown.getMessage().contains("Byte order mark is only permitted at the start"));
+
+        thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("key = \"\uFEFF\"")
+        );
+        assertTrue(thrown.getMessage().contains("Byte order mark is only permitted at the start"));
+    }
+
+    @Test
     public void intTypes() throws Exception {
         assertEquals(
                 JsonNodeFactory.instance.objectNode()


### PR DESCRIPTION
Handles TOML byte order marks according to the corpus expectations.

Changes:
- Accepts a single leading BOM at document start.
- Rejects BOM characters elsewhere in TOML input.
- Escapes BOM content when generating strings instead of emitting it literally.

Resolves #665