### PR TITLE
Reject invalid TOML Unicode scalars

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -87,7 +87,14 @@ implementations)
 #665: (toml) TOML parser: leading UTF-8 BOM rejected as 'Unknown token'
  (reported by @rajulbhatnagar)
  (fix by @yawkat)
+#666: (toml) TOML parser: invalid UTF-8 byte sequences not rejected
+ (reported by @rajulbhatnagar)
+ (fix by @yawkat)
+#668: (toml) TOML parser: surrogate-half unicode escapes accepted in strings
+ (reported by @rajulbhatnagar)
+ (fix by @yawkat)
 
+3.1.4 (not yet released)
 3.1.3 (01-May-2026)
 3.1.2 (11-Apr-2026)
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlFactory.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlFactory.java
@@ -3,6 +3,7 @@ package tools.jackson.dataformat.toml;
 import java.io.*;
 
 import tools.jackson.core.*;
+import tools.jackson.core.TokenStreamLocation;
 import tools.jackson.core.base.TextualTSFactory;
 import tools.jackson.core.io.IOContext;
 import tools.jackson.core.io.UTF8Writer;
@@ -242,6 +243,9 @@ public final class TomlFactory extends TextualTSFactory
             } else {
                 return TomlParser.parse(this, ctxt, readFeatures, r0);
             }
+        } catch (CharConversionException e) {
+            TokenStreamLocation location = new TokenStreamLocation(ctxt.contentReference(), -1, -1, -1, -1);
+            throw new TomlStreamReadException(null, e.getMessage(), location, e);
         } catch (IOException e) {
             throw _wrapIOFailure(e);
         }

--- a/toml/src/main/java/tools/jackson/dataformat/toml/UTF8Reader.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/UTF8Reader.java
@@ -249,7 +249,7 @@ public final class UTF8Reader
                 needed = 2;
             } else if ((c & 0xF8) == 0xF0) {
                 // 4 bytes; double-char BS, with surrogates and all...
-                c = (c & 0x0F);
+                c = (c & 0x07);
                 needed = 3;
             } else {
                 reportInvalidInitial(c & 0xFF, outPtr-start);
@@ -283,6 +283,12 @@ public final class UTF8Reader
                         reportInvalidOther(d & 0xFF, outPtr-start);
                     }
                     c = (c << 6) | (d & 0x3F);
+                    if (c < 0x10000) {
+                        reportInvalid(c, outPtr-start, "overlong encoding");
+                    }
+                    if (c > Character.MAX_CODE_POINT) {
+                        reportInvalid(c, outPtr-start, "not a valid Unicode scalar value");
+                    }
                     /* Ugh. Need to mess with surrogates. Ok; let's inline them
                      * there, then, if there's room: if only room for one,
                      * need to save the surrogate for the rainy day...
@@ -299,16 +305,17 @@ public final class UTF8Reader
                     }
                     // sure, let's fall back to normal processing:
                 }
-                // Otherwise, should we check that 3-byte chars are
-                // legal ones (should not expand to surrogates?
-                // For now, let's not...
-                /*
                 else {
-                    if (c >= 0xD800 && c < 0xE000) {
-                        reportInvalid(c, outPtr-start, "(a surrogate character) ");
+                    if (c < 0x800) {
+                        reportInvalid(c, outPtr-start, "overlong encoding");
+                    }
+                    // Like jackson-core#363: surrogates are not legal UTF-8 scalar values.
+                    if (c >= Character.MIN_SURROGATE && c <= Character.MAX_SURROGATE) {
+                        reportInvalid(c, outPtr-start, "not a valid Unicode scalar value");
                     }
                 }
-                */
+            } else if (c < 0x80) {
+                reportInvalid(c, outPtr-start, "overlong encoding");
             }
             cbuf[outPtr++] = (char) c;
             if (inPtr >= inBufLen) {
@@ -444,6 +451,15 @@ public final class UTF8Reader
 
         throw new CharConversionException("Invalid UTF-8 start byte 0x"+Integer.toHexString(mask)
                 +" (at char #"+charPos+", byte #"+bytePos+")");
+    }
+
+    private void reportInvalid(int value, int offset, String msg) throws IOException
+    {
+        int bytePos = _byteCount + _inputPtr - 1;
+        int charPos = _charCount + offset;
+
+        throw new CharConversionException("Invalid UTF-8 character 0x"+Integer.toHexString(value)
+                +" ("+msg+") (at char #"+charPos+", byte #"+bytePos+")");
     }
 
     private void reportInvalidOther(int mask, int offset)

--- a/toml/src/main/jflex/tools/jackson/dataformat/toml/toml.jflex
+++ b/toml/src/main/jflex/tools/jackson/dataformat/toml/toml.jflex
@@ -81,15 +81,15 @@ this.textBuffer = ioContext.constructReadConstrainedTextBuffer();
       }
   }
 
-  private void appendUnicodeEscapeShort() {
+  private void appendUnicodeEscapeShort() throws TomlStreamReadException {
       int value = (Character.digit(yycharat(2), 16) << 12) |
                    (Character.digit(yycharat(3), 16) << 8) |
                    (Character.digit(yycharat(4), 16) << 4) |
                    Character.digit(yycharat(5), 16);
-      textBuffer.append((char) value);
+      appendUnicodeScalar(value);
   }
 
-  private void appendUnicodeEscapeLong() {
+  private void appendUnicodeEscapeLong() throws TomlStreamReadException {
      int value = (Character.digit(yycharat(2), 16) << 28) |
                  (Character.digit(yycharat(3), 16) << 24) |
                  (Character.digit(yycharat(4), 16) << 20) |
@@ -98,17 +98,20 @@ this.textBuffer = ioContext.constructReadConstrainedTextBuffer();
                  (Character.digit(yycharat(7), 16) << 8) |
                  (Character.digit(yycharat(8), 16) << 4) |
                  Character.digit(yycharat(9), 16);
-     if (Character.isValidCodePoint(value)) {
-         // "Such code points can be represented using a single char."
-         if (value <= Character.MAX_VALUE) {
-             textBuffer.append((char) value);
-         } else {
-             textBuffer.append(Character.highSurrogate(value));
-             textBuffer.append(Character.lowSurrogate(value));
-         }
-     } else {
-         throw errorContext.atPosition(this).generic("Invalid code point " + Integer.toHexString(value));
-     }
+     appendUnicodeScalar(value);
+  }
+
+  private void appendUnicodeScalar(int value) throws TomlStreamReadException {
+      if (!Character.isValidCodePoint(value)
+              || (value >= Character.MIN_SURROGATE && value <= Character.MAX_SURROGATE)) {
+          throw errorContext.atPosition(this).generic("Invalid code point " + Integer.toHexString(value));
+      }
+      if (value <= Character.MAX_VALUE) {
+          textBuffer.append((char) value);
+      } else {
+          textBuffer.append(Character.highSurrogate(value));
+          textBuffer.append(Character.lowSurrogate(value));
+      }
   }
 
   int getLine() { return yyline; }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/FuzzTomlRead57237Test.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/FuzzTomlRead57237Test.java
@@ -29,7 +29,7 @@ public class FuzzTomlRead57237Test extends TomlMapperTestBase
                 fail("Should not pass");
             } catch (StreamReadException e) {
                 // Possibly not what we should get; tweak once working
-                verifyException(e, "Premature end of file");
+                verifyException(e, "Invalid UTF-8 character");
             }
         }
     }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/FuzzTomlReadTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/FuzzTomlReadTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.StreamReadConstraints;
 import tools.jackson.core.StreamWriteConstraints;
-import tools.jackson.core.exc.JacksonIOException;
 import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.core.exc.StreamReadException;
 import tools.jackson.databind.JsonNode;
@@ -48,7 +47,7 @@ public class FuzzTomlReadTest extends TomlMapperTestBase
         try {
             TOML_MAPPER.readTree(INPUT);
             fail("Should not pass");
-        } catch (JacksonIOException e) {
+        } catch (StreamReadException e) {
             verifyException(e, "Unexpected EOF in the middle of a multi-byte");
             verifyException(e, "got 1, needed 2");
         }
@@ -81,7 +80,7 @@ public class FuzzTomlReadTest extends TomlMapperTestBase
                 TOML_MAPPER.readTree(is);
                 fail("Should not pass");
             } catch (StreamReadException e) {
-                verifyException(e, "EOF in wrong state");
+                verifyException(e, "Invalid UTF-8 character");
             }
         }
     }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -988,6 +988,25 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void unicodeEscapeSurrogateInvalid() throws Exception {
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("short = \"\\uD800\"")
+        );
+        assertTrue(thrown.getMessage().contains("Invalid code point d800"));
+
+        thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("long = \"\\U0000DFFF\"")
+        );
+        assertTrue(thrown.getMessage().contains("Invalid code point dfff"));
+    }
+
+    @Test
+    public void unicodeEscapeValidSupplementaryScalar() throws Exception {
+        ObjectNode node = toml("value = \"\\U0001D800\"");
+        assertEquals(new String(Character.toChars(0x1D800)), node.get("value").asString());
+    }
+
+    @Test
     public void intTypes() throws Exception {
         assertEquals(
                 JsonNodeFactory.instance.objectNode()

--- a/toml/src/test/java/tools/jackson/dataformat/toml/UTF8ReaderTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/UTF8ReaderTest.java
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UTF8ReaderTest
 {
@@ -38,5 +38,42 @@ public class UTF8ReaderTest
         assertEquals(emojiStr, result);
 
         reader.close();
+    }
+    @Test
+    public void invalidUtf8Scalars() throws IOException {
+        assertInvalid(new byte[] { (byte) 0xC0, (byte) 0x80 });
+        assertInvalid(new byte[] { (byte) 0xE0, (byte) 0x80, (byte) 0x80 });
+        assertInvalid(new byte[] { (byte) 0xED, (byte) 0xA0, (byte) 0x80 });
+        assertInvalid(new byte[] { (byte) 0xED, (byte) 0xBF, (byte) 0xBF });
+        assertInvalid(new byte[] { (byte) 0xF4, (byte) 0x90, (byte) 0x80, (byte) 0x80 });
+    }
+
+    @Test
+    public void validUtf8ScalarBoundaries() throws IOException {
+        assertValid("\uD7FF");
+        assertValid("\uE000");
+        assertValid(new String(Character.toChars(Character.MAX_CODE_POINT)));
+    }
+
+    @Test
+    public void validFourByteScalar() throws IOException {
+        assertValid("\uD83D\uDE00");
+    }
+
+    private void assertInvalid(byte[] utf8Bytes) throws IOException {
+        try (UTF8Reader reader = UTF8Reader.construct(utf8Bytes, 0, utf8Bytes.length)) {
+            assertThrows(CharConversionException.class, () -> reader.read(new char[4], 0, 4));
+        }
+    }
+
+    private void assertValid(String value) throws IOException {
+        byte[] utf8Bytes = value.getBytes(StandardCharsets.UTF_8);
+        try (UTF8Reader reader = UTF8Reader.construct(utf8Bytes, 0, utf8Bytes.length)) {
+            char[] buf = new char[value.length()];
+
+            assertEquals(value.length(), reader.read(buf, 0, buf.length));
+            assertEquals(value, new String(buf));
+            assertEquals(-1, reader.read(buf, 0, buf.length));
+        }
     }
 }


### PR DESCRIPTION
Rejects invalid Unicode scalar values in TOML byte input and string escapes.

Changes:
- Rejects overlong UTF-8, surrogate UTF-8 code points, and values above `U+10FFFF`.
- Wraps UTF-8 conversion failures as stream-read failures.
- Rejects surrogate values in `\u` / `\U` string escapes while preserving valid supplementary scalars.
- Updates fuzz expectations for stricter UTF-8 errors.

Resolves #666
Resolves #668