### PR TITLE
Reject invalid TOML dotted table extensions

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -93,6 +93,10 @@ implementations)
 #668: (toml) TOML parser: surrogate-half unicode escapes accepted in strings
  (reported by @rajulbhatnagar)
  (fix by @yawkat)
+#669: (toml) TOML parser: invalid dotted-key extension of explicit
+  tables / AOT not rejected
+ (reported by @rajulbhatnagar)
+ (fix by @yawkat)
 
 3.1.4 (not yet released)
 3.1.3 (01-May-2026)

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -109,6 +109,7 @@ class TomlParser {
                     throw errorContext.atPosition(lexer).generic("Table redefined");
                 }
                 currentTable.defined = true;
+                currentTable.explicitlyDefined = true;
                 pollExpected(TomlToken.STD_TABLE_CLOSE, Lexer.EXPECT_EOL);
             } else if (token == TomlToken.ARRAY_TABLE_OPEN) {
                 pollExpected(TomlToken.ARRAY_TABLE_OPEN, Lexer.EXPECT_INLINE_KEY);
@@ -118,6 +119,7 @@ class TomlParser {
                     throw errorContext.atPosition(lexer).generic("Array already finished");
                 }
                 currentTable = (TomlObjectNode) array.addObject();
+                currentTable.explicitlyDefined = true;
                 pollExpected(TomlToken.ARRAY_TABLE_CLOSE, Lexer.EXPECT_EOL);
             } else {
                 throw errorContext.atPosition(lexer).unexpectedToken(token, "key or table");
@@ -140,12 +142,6 @@ class TomlParser {
             if (node.closed) {
                 throw errorContext.atPosition(lexer).generic("Object already closed");
             }
-            if (!forTable) {
-                /* "Dotted keys create and define a table for each key part before the last one, provided that such
-                 * tables were not previously created." */
-                node.defined = true;
-            }
-
             TomlToken partToken = peek();
             String part;
             if (partToken == TomlToken.STRING) {
@@ -164,8 +160,14 @@ class TomlParser {
             JsonNode existing = node.get(part);
             if (existing == null) {
                 node = (TomlObjectNode) node.putObject(part);
+                if (!forTable) {
+                    node.defined = true;
+                }
             } else if (existing.isObject()) {
                 node = (TomlObjectNode) existing;
+                if (!forTable && node.explicitlyDefined) {
+                    throw errorContext.atPosition(lexer).generic("Dotted key cannot extend explicitly defined table");
+                }
             } else if (existing.isArray()) {
                 /* "Any reference to an array of tables points to the most recently defined table element of the array.
                  * This allows you to define sub-tables, and even sub-arrays of tables, inside the most recent table."
@@ -177,6 +179,9 @@ class TomlParser {
                 TomlArrayNode array = (TomlArrayNode) existing;
                 if (array.closed) {
                     throw errorContext.atPosition(lexer).generic("Array already closed");
+                }
+                if (!forTable) {
+                    throw errorContext.atPosition(lexer).generic("Dotted key cannot extend array of tables");
                 }
                 // Only arrays declared by array tables are not closed, and those are always arrays of objects.
                 node = (TomlObjectNode) array.get(array.size() - 1);
@@ -511,6 +516,7 @@ class TomlParser {
     private static class TomlObjectNode extends ObjectNode {
         boolean closed = false;
         boolean defined = false;
+        boolean explicitlyDefined = false;
 
         TomlObjectNode(JsonNodeFactory nc) {
             super(nc);

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -161,6 +161,9 @@ class TomlParser {
             if (existing == null) {
                 node = (TomlObjectNode) node.putObject(part);
                 if (!forTable) {
+                    /* "Dotted keys create and define a table for each key part before
+                     * the last one, provided that such tables were not previously created."
+                     */
                     node.defined = true;
                 }
             } else if (existing.isObject()) {
@@ -515,7 +518,11 @@ class TomlParser {
     @SuppressWarnings("serial") // only used internally, no need to be JDK serializable
     private static class TomlObjectNode extends ObjectNode {
         boolean closed = false;
+        // True for both explicit headers and dotted-key super-tables; gates "Table redefined".
         boolean defined = false;
+        // Subset of `defined`: set only by [table] or [[array-of-tables]] headers,
+        // not by dotted-key super-tables.
+        // Gates rejection of dotted-key extensions of an already-explicit table.
         boolean explicitlyDefined = false;
 
         TomlObjectNode(JsonNodeFactory nc) {

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -774,6 +774,17 @@ public class TomlParserTest extends TomlMapperTestBase {
         assertTrue(thrown.getMessage().contains("Dotted key cannot extend array of tables"));
     }
 
+    // Value arrays are closed once parsed, so dotted-key extension of one must be rejected
+    // via the "Array already closed" path (not via the AOT path tested above).
+    @Test
+    public void dottedKeyCannotExtendClosedValueArray() throws Exception {
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("apple = []\n" +
+                        "apple.color = \"red\"")
+        );
+        assertTrue(thrown.getMessage().contains("Array already closed"));
+    }
+
     @Test
     public void inlineTable() throws Exception {
         assertEquals(

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -755,6 +755,26 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void dottedKeyCannotExtendExplicitTable() throws Exception {
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("[fruit.apple]\n" +
+                        "[fruit]\n" +
+                        "apple.color = \"red\"")
+        );
+        assertTrue(thrown.getMessage().contains("Dotted key cannot extend explicitly defined table"));
+    }
+
+    @Test
+    public void dottedKeyCannotExtendArrayTable() throws Exception {
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml("[[fruit.apple]]\n" +
+                        "[fruit]\n" +
+                        "apple.color = \"red\"")
+        );
+        assertTrue(thrown.getMessage().contains("Dotted key cannot extend array of tables"));
+    }
+
+    @Test
     public void inlineTable() throws Exception {
         assertEquals(
                 json("{\"name\": {\"first\": \"Tom\", \"last\": \"Preston-Werner\"}, \"point\": {\"x\": 1, \"y\": 2}, \"animal\": {\"type\": {\"name\": \"pug\"}}}"),


### PR DESCRIPTION
Rejects invalid dotted-key extensions of explicitly defined tables and arrays-of-tables.

Changes:
- Tracks explicitly defined TOML tables.
- Rejects dotted keys that extend explicit tables in invalid corpus cases.
- Rejects dotted key traversal through arrays-of-tables.
- Adds regression tests for explicit-table and array-table extension failures.

Resolves #669