### PR TITLE
Add opt-in TOML date/time validation

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -90,6 +90,9 @@ implementations)
 #666: (toml) TOML parser: invalid UTF-8 byte sequences not rejected
  (reported by @rajulbhatnagar)
  (fix by @yawkat)
+#667: (toml) TOML parser: out-of-range datetime/date/time field values not rejected
+ (reported by @rajulbhatnagar)
+ (fix by @yawkat)
 #668: (toml) TOML parser: surrogate-half unicode escapes accepted in strings
  (reported by @rajulbhatnagar)
  (fix by @yawkat)

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -17,7 +17,7 @@ import tools.jackson.databind.node.*;
 
 class TomlParser {
     private static final JsonNodeFactory factory = new JsonNodeFactoryImpl();
-    private static final int MAX_CHARS_TO_REPORT = 1000;
+    public static final int MAX_CHARS_TO_REPORT = 1000;
 
     private final TomlFactory tomlFactory;
 
@@ -226,6 +226,10 @@ class TomlParser {
         }
     }
 
+    // Helper method for ensuring text content included in exception is
+    // of bound length, to avoid excessive messages.
+    //
+    // @since 3.2
     private String reportText(String text) {
         if (text.length() <= MAX_CHARS_TO_REPORT) {
             return text;

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -17,7 +17,7 @@ import tools.jackson.databind.node.*;
 
 class TomlParser {
     private static final JsonNodeFactory factory = new JsonNodeFactoryImpl();
-    public static final int MAX_CHARS_TO_REPORT = 1000;
+    static final int MAX_CHARS_TO_REPORT = 1000;
 
     private final TomlFactory tomlFactory;
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.time.*;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 
 import tools.jackson.core.io.IOContext;
@@ -218,8 +219,9 @@ class TomlParser {
     }
 
     private JsonNode parseDateTime(int nextState) throws IOException {
-        String text = lexer.yytext();
-        TomlToken token = poll(nextState);
+        String originalText = lexer.yytext();
+        String text = originalText;
+        TomlToken token = peek();
         // The time delimiter can be [Tt ]. java.time supports [Tt], and TOML accepts lowercase z.
         if (token == TomlToken.LOCAL_DATE_TIME || token == TomlToken.OFFSET_DATE_TIME) {
             StringBuilder normalized = null;
@@ -238,14 +240,15 @@ class TomlParser {
             }
         }
 
-        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)) {
-            Temporal value;
-            if (token == TomlToken.LOCAL_DATE) {
-                value = LocalDate.parse(text);
-            } else if (token == TomlToken.LOCAL_TIME) {
-                value = LocalTime.parse(text);
-            } else {
-                if (token == TomlToken.LOCAL_DATE_TIME) {
+        Temporal value = null;
+        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)
+                || TomlReadFeature.VALIDATE_DATE_TIME.enabledIn(options)) {
+            try {
+                if (token == TomlToken.LOCAL_DATE) {
+                    value = LocalDate.parse(text);
+                } else if (token == TomlToken.LOCAL_TIME) {
+                    value = LocalTime.parse(text);
+                } else if (token == TomlToken.LOCAL_DATE_TIME) {
                     value = LocalDateTime.parse(text);
                 } else if (token == TomlToken.OFFSET_DATE_TIME) {
                     value = OffsetDateTime.parse(text);
@@ -253,11 +256,15 @@ class TomlParser {
                     VersionUtil.throwInternal();
                     throw new AssertionError();
                 }
+            } catch (DateTimeParseException e) {
+                throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
             }
-            return factory.pojoNode(value);
-        } else {
-            return factory.stringNode(text);
         }
+        pollExpected(token, nextState);
+        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)) {
+            return factory.pojoNode(value);
+        }
+        return factory.stringNode(text);
     }
 
     private JsonNode parseInt(int nextState) throws IOException {

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -255,9 +255,9 @@ class TomlParser {
             }
         }
 
-        Temporal value = null;
-        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)
-                || TomlReadFeature.VALIDATE_DATE_TIME.enabledIn(options)) {
+        boolean parseJavaTime = TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options);
+        if (parseJavaTime || TomlReadFeature.VALIDATE_DATE_TIME.enabledIn(options)) {
+            Temporal value;
             try {
                 if (token == TomlToken.LOCAL_DATE) {
                     value = LocalDate.parse(text);
@@ -274,11 +274,13 @@ class TomlParser {
             } catch (DateTimeParseException e) {
                 throw errorContext.atPosition(lexer).invalidDateTime(e, reportText(originalText));
             }
+            pollExpected(token, nextState);
+            if (parseJavaTime) {
+                return factory.pojoNode(value);
+            }
+            return factory.stringNode(text);
         }
         pollExpected(token, nextState);
-        if (TomlReadFeature.PARSE_JAVA_TIME.enabledIn(options)) {
-            return factory.pojoNode(value);
-        }
         return factory.stringNode(text);
     }
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -218,6 +218,13 @@ class TomlParser {
         }
     }
 
+    private String reportText(String text) {
+        if (text.length() <= MAX_CHARS_TO_REPORT) {
+            return text;
+        }
+        return text.substring(0, MAX_CHARS_TO_REPORT) + " [truncated]";
+    }
+
     private JsonNode parseDateTime(int nextState) throws IOException {
         String originalText = lexer.yytext();
         String text = originalText;
@@ -257,7 +264,7 @@ class TomlParser {
                     throw new AssertionError();
                 }
             } catch (DateTimeParseException e) {
-                throw errorContext.atPosition(lexer).invalidDateTime(e, originalText);
+                throw errorContext.atPosition(lexer).invalidDateTime(e, reportText(originalText));
             }
         }
         pollExpected(token, nextState);

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlReadFeature.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlReadFeature.java
@@ -18,7 +18,17 @@ public enum TomlReadFeature
      *<p>
      * Feature is disabled by default.
      */
-    PARSE_JAVA_TIME(false);
+    PARSE_JAVA_TIME(false),
+
+    /**
+     * Whether TOML date/time values should be validated when they are returned as strings.
+     * <p>
+     * {@link #PARSE_JAVA_TIME} always validates date/time values while constructing {@code java.time}
+     * values. This feature only affects the default string representation mode.
+     * <p>
+     * Feature is disabled by default.
+     */
+    VALIDATE_DATE_TIME(false);
 
     private final boolean _defaultState;
     private final int _mask;

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlReadFeature.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlReadFeature.java
@@ -27,6 +27,8 @@ public enum TomlReadFeature
      * values. This feature only affects the default string representation mode.
      * <p>
      * Feature is disabled by default.
+     *
+     * @since 3.2
      */
     VALIDATE_DATE_TIME(false);
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
@@ -10,10 +10,6 @@ public class TomlStreamReadException
 {
     private static final long serialVersionUID = 1L;
 
-    // Cap on cause detail length included in wrapper messages; the cause itself
-    // (with its full message) remains accessible via getCause().
-    private static final int MAX_CAUSE_DETAIL_CHARS = 1000;
-
     TomlStreamReadException(JsonParser p, String msg, TokenStreamLocation loc) {
         super(p, msg, loc);
     }
@@ -78,8 +74,8 @@ public class TomlStreamReadException
 
             TomlStreamReadException invalidDateTime(Exception cause, String value) {
                 String detail = cause.getMessage();
-                if (detail != null && detail.length() > MAX_CAUSE_DETAIL_CHARS) {
-                    detail = detail.substring(0, MAX_CAUSE_DETAIL_CHARS) + " [truncated]";
+                if (detail != null && detail.length() > TomlParser.MAX_CHARS_TO_REPORT) {
+                    detail = detail.substring(0, TomlParser.MAX_CHARS_TO_REPORT) + " [truncated]";
                 }
                 return new TomlStreamReadException(parser,
                         "Invalid date/time value ('"+value+"'), problem: "+detail, location, cause);

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
@@ -10,6 +10,13 @@ public class TomlStreamReadException
 {
     private static final long serialVersionUID = 1L;
 
+    private static String _truncateDetail(String detail) {
+        if (detail != null && detail.length() > TomlParser.MAX_CHARS_TO_REPORT) {
+            return detail.substring(0, TomlParser.MAX_CHARS_TO_REPORT) + " [truncated]";
+        }
+        return detail;
+    }
+
     TomlStreamReadException(JsonParser p, String msg, TokenStreamLocation loc) {
         super(p, msg, loc);
     }
@@ -69,16 +76,14 @@ public class TomlStreamReadException
 
             TomlStreamReadException invalidNumber(Exception cause, String value) {
                 return new TomlStreamReadException(parser,
-                        "Invalid number representation ('"+value+"'), problem: "+cause.getMessage(), location, cause);
+                        "Invalid number representation ('"+value+"'), problem: "+_truncateDetail(cause.getMessage()),
+                        location, cause);
             }
 
             TomlStreamReadException invalidDateTime(Exception cause, String value) {
-                String detail = cause.getMessage();
-                if (detail != null && detail.length() > TomlParser.MAX_CHARS_TO_REPORT) {
-                    detail = detail.substring(0, TomlParser.MAX_CHARS_TO_REPORT) + " [truncated]";
-                }
                 return new TomlStreamReadException(parser,
-                        "Invalid date/time value ('"+value+"'), problem: "+detail, location, cause);
+                        "Invalid date/time value ('"+value+"'), problem: "+_truncateDetail(cause.getMessage()),
+                        location, cause);
             }
         }
     }

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
@@ -71,6 +71,11 @@ public class TomlStreamReadException
                 return new TomlStreamReadException(parser,
                         "Invalid number representation ('"+value+"'), problem: "+cause.getMessage(), location, cause);
             }
+
+            TomlStreamReadException invalidDateTime(Exception cause, String value) {
+                return new TomlStreamReadException(parser,
+                        "Invalid date/time value ('"+value+"'), problem: "+cause.getMessage(), location, cause);
+            }
         }
     }
 }

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlStreamReadException.java
@@ -10,6 +10,10 @@ public class TomlStreamReadException
 {
     private static final long serialVersionUID = 1L;
 
+    // Cap on cause detail length included in wrapper messages; the cause itself
+    // (with its full message) remains accessible via getCause().
+    private static final int MAX_CAUSE_DETAIL_CHARS = 1000;
+
     TomlStreamReadException(JsonParser p, String msg, TokenStreamLocation loc) {
         super(p, msg, loc);
     }
@@ -73,8 +77,12 @@ public class TomlStreamReadException
             }
 
             TomlStreamReadException invalidDateTime(Exception cause, String value) {
+                String detail = cause.getMessage();
+                if (detail != null && detail.length() > MAX_CAUSE_DETAIL_CHARS) {
+                    detail = detail.substring(0, MAX_CAUSE_DETAIL_CHARS) + " [truncated]";
+                }
                 return new TomlStreamReadException(parser,
-                        "Invalid date/time value ('"+value+"'), problem: "+cause.getMessage(), location, cause);
+                        "Invalid date/time value ('"+value+"'), problem: "+detail, location, cause);
             }
         }
     }

--- a/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/ComplianceInvalidTest.java
@@ -14,7 +14,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ComplianceInvalidTest extends TomlMapperTestBase
 {
-    private static final ObjectMapper MAPPER = newTomlMapper();
+    private static final ObjectMapper MAPPER = TomlMapper.builder()
+            .enable(TomlReadFeature.VALIDATE_DATE_TIME)
+            .build();
 
     @ParameterizedTest
     @MethodSource("data")

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -527,6 +527,15 @@ public class TomlParserTest extends TomlMapperTestBase {
         );
         assertTrue(thrown.getMessage().contains("Invalid date/time value ('24:00:00')"));
         assertInstanceOf(java.time.format.DateTimeParseException.class, thrown.getCause());
+
+        StringBuilder longTime = new StringBuilder("time = 12:00:00.");
+        for (int i = 0; i < 2000; i++) {
+            longTime.append('1');
+        }
+        thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml(tomlFactory, longTime.toString())
+        );
+        assertTrue(thrown.getMessage().contains("[truncated]"));
     }
 
     @Test

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -45,12 +45,10 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     static ObjectNode toml(TomlFactory factory, String toml) throws Exception {
-        // 07-Mar-2023, tatu: Due to refactoring, ended up here...
-        int options = TomlReadFeature.PARSE_JAVA_TIME.getMask();
         return TomlParser.parse(
                 factory,
                 testIOContext(),
-                options,
+                factory.getFormatReadFeatures(),
                 new StringReader(toml)
                 );
     }
@@ -516,6 +514,11 @@ public class TomlParserTest extends TomlMapperTestBase {
         TomlFactory tomlFactory = TomlFactory.builder()
                 .enable(TomlReadFeature.VALIDATE_DATE_TIME)
                 .build();
+        // Valid literal under VALIDATE_DATE_TIME alone still surfaces as a string node
+        // (not a pojoNode) — guards against the flag silently aliasing PARSE_JAVA_TIME.
+        assertEquals(json("{\"date\": \"1979-05-27\"}"),
+                toml(tomlFactory, "date = 1979-05-27"));
+
         TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
                 toml(tomlFactory, "date = 2024-02-30")
         );

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlParserTest.java
@@ -509,6 +509,27 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void dateTimeValidationFeature() throws Exception {
+        // default string mode preserves historical behavior and does not validate date/time ranges
+        assertEquals(json("{\"date\": \"2024-02-30\"}"), toml("date = 2024-02-30"));
+
+        TomlFactory tomlFactory = TomlFactory.builder()
+                .enable(TomlReadFeature.VALIDATE_DATE_TIME)
+                .build();
+        TomlStreamReadException thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml(tomlFactory, "date = 2024-02-30")
+        );
+        assertTrue(thrown.getMessage().contains("Invalid date/time value ('2024-02-30')"));
+        assertInstanceOf(java.time.format.DateTimeParseException.class, thrown.getCause());
+
+        thrown = assertThrows(TomlStreamReadException.class, () ->
+                toml(tomlFactory, "time = 24:00:00")
+        );
+        assertTrue(thrown.getMessage().contains("Invalid date/time value ('24:00:00')"));
+        assertInstanceOf(java.time.format.DateTimeParseException.class, thrown.getCause());
+    }
+
+    @Test
     public void ldt() throws Exception {
         assertEquals(
                 json("{\"ldt1\": \"1979-05-27T07:32:00\", \"ldt2\": \"1979-05-27T00:32:00.999999\"}"),


### PR DESCRIPTION
Adds an off-by-default TOML read feature for validating date/time values when the parser returns them as strings.

Changes:
- Adds `TomlReadFeature.VALIDATE_DATE_TIME`, disabled by default.
- Keeps default string-mode behavior unchanged for performance.
- Keeps `PARSE_JAVA_TIME` validation unchanged because Java time objects require semantic parsing.
- Lets the opt-in invalid corpus harness exercise date/time range validation.

Resolves #667