### PR TITLE
Add TOML compliance workflow

### DIFF
--- a/.github/workflows/toml-compliance.yml
+++ b/.github/workflows/toml-compliance.yml
@@ -1,0 +1,43 @@
+name: TOML Compliance
+
+on:
+  push:
+    branches: ['3.*']
+    paths:
+    - '.github/workflows/toml-compliance.yml'
+    - 'toml/**'
+  pull_request:
+    branches:
+    paths:
+    - '.github/workflows/toml-compliance.yml'
+    - 'toml/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  toml-compliance:
+    runs-on: 'ubuntu-24.04'
+    env:
+      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      TOML_TEST_DIR: ${{ github.workspace }}/../toml-test
+    steps:
+    - name: Check out jackson-dataformats-text
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        path: jackson-dataformats-text
+    - name: Check out toml-test corpus
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: toml-lang/toml-test
+        path: toml-test
+    - name: Set up JDK
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
+    - name: Run TOML compliance tests
+      working-directory: jackson-dataformats-text
+      run: ./mvnw -B -q -ff -ntp -pl toml -Dtest=ComplianceValidTest,ComplianceInvalidTest -Dtoml.corpus.dir="$TOML_TEST_DIR" test

--- a/.github/workflows/toml-compliance.yml
+++ b/.github/workflows/toml-compliance.yml
@@ -20,7 +20,6 @@ jobs:
   toml-compliance:
     runs-on: 'ubuntu-24.04'
     env:
-      JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
       TOML_TEST_DIR: ${{ github.workspace }}/toml-test
     steps:
     - name: Check out jackson-dataformats-text
@@ -36,7 +35,7 @@ jobs:
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
         cache: 'maven'
     - name: Run TOML compliance tests
       working-directory: jackson-dataformats-text

--- a/.github/workflows/toml-compliance.yml
+++ b/.github/workflows/toml-compliance.yml
@@ -7,7 +7,7 @@ on:
     - '.github/workflows/toml-compliance.yml'
     - 'toml/**'
   pull_request:
-    branches:
+    branches: ['3.*']
     paths:
     - '.github/workflows/toml-compliance.yml'
     - 'toml/**'
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: toml-lang/toml-test
+        ref: v2.2.0
         path: toml-test
     - name: Set up JDK
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/toml-compliance.yml
+++ b/.github/workflows/toml-compliance.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-      TOML_TEST_DIR: ${{ github.workspace }}/../toml-test
+      TOML_TEST_DIR: ${{ github.workspace }}/toml-test
     steps:
     - name: Check out jackson-dataformats-text
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Adds a dedicated GitHub Actions workflow for the TOML compliance corpus.

Changes:
- Checks out this repository and the official `toml-lang/toml-test` corpus pinned at `v2.2.0`.
- Sets up Temurin JDK 21 using the repository's pinned `setup-java` action style.
- Runs `ComplianceValidTest` and `ComplianceInvalidTest` with `-Dtoml.corpus.dir` pointing at the checked-out corpus.
- Triggers on TOML/workflow changes for the `3.*` line and manual dispatch.