### PR TITLE
Validate integer length for hex/octal/binary radix literals

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -287,3 +287,8 @@ Henning Langhorst (@HenningLanghorst)
 * Reported #615 (csv): Feature `CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL` ignored
   when preceding column is quoted
  (2.18.7)
+
+Shanchao Li (@tonguaroot)
+
+* Fixed #679: (toml) Validate integer length for hex/octal/binary radix literals
+ (2.18.8)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,11 @@ Active Maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.8 (not yet released)
+
+#679: (toml) Validate integer length for hex/octal/binary radix literals
+ (fix by @tonghuaroot)
+
 2.18.7 (24-Apr-2026)
 
 #615: (csv) Feature `CsvReadFeature.EMPTY_UNQUOTED_STRING_AS_NULL` ignored

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -295,6 +295,14 @@ class Parser {
             char baseChar = buffer[start + 1];
 
             if (baseChar == 'x' || baseChar == 'o' || baseChar == 'b') {
+                try {
+                    tomlFactory.streamReadConstraints().validateIntegerLength(length);
+                } catch (StreamConstraintsException e) {
+                    final String reportNum = length <= MAX_CHARS_TO_REPORT
+                            ? new String(buffer, start, length)
+                            : new String(buffer, start, MAX_CHARS_TO_REPORT) + " [truncated]";
+                    throw errorContext.atPosition(lexer).invalidNumber(e, reportNum);
+                }
                 start += 2;
                 length -= 2;
                 String text = new String(buffer, start, length);

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -376,19 +376,17 @@ class Parser {
                 return factory.numberNode(v);
             }
         }
-        String text = null;
         try {
             tomlFactory.streamReadConstraints().validateIntegerLength(length);
-        } catch (NumberFormatException | StreamConstraintsException e) {
-            final String reportNum = length <= MAX_CHARS_TO_REPORT ?
-                    text == null ? new String(buffer, start, length) : text :
-                    (text == null ? new String(buffer, start, MAX_CHARS_TO_REPORT) : text.substring(0, MAX_CHARS_TO_REPORT))
-                            + " [truncated]";
+        } catch (StreamConstraintsException e) {
+            final String reportNum = length <= MAX_CHARS_TO_REPORT
+                    ? new String(buffer, start, length)
+                    : new String(buffer, start, MAX_CHARS_TO_REPORT) + " [truncated]";
             throw errorContext.atPosition(lexer).invalidNumber(e, reportNum);
         }
-        text = new String(buffer, start, length);
         return factory.numberNode(NumberInput.parseBigInteger(
-                text, tomlFactory.isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)));
+                new String(buffer, start, length),
+                tomlFactory.isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)));
     }
 
     private JsonNode parseFloat(int nextState) throws IOException {

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/LongTokenTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/LongTokenTest.java
@@ -67,6 +67,37 @@ public class LongTokenTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void integerTooLongBinary() throws IOException {
+        // default TomlFactory has max num length of 1000
+        assertRadixIntegerRejected("0b1");
+    }
+
+    @Test
+    public void integerTooLongOctal() throws IOException {
+        assertRadixIntegerRejected("0o1");
+    }
+
+    @Test
+    public void integerTooLongHex() throws IOException {
+        assertRadixIntegerRejected("0xa");
+    }
+
+    private void assertRadixIntegerRejected(String prefixAndFirstDigit) throws IOException {
+        final ObjectMapper mapper = newTomlMapper();
+        StringBuilder toml = new StringBuilder("foo = ").append(prefixAndFirstDigit);
+        for (int i = 0; i < SCALE; i++) {
+            toml.append('0');
+        }
+        try {
+            mapper.readTree(toml.toString());
+            Assert.fail("expected TomlStreamReadException for radix integer of length " + (prefixAndFirstDigit.length() + SCALE));
+        } catch (TomlStreamReadException e) {
+            Assert.assertTrue("exception message contains truncated number: " + e.getMessage(),
+                    e.getMessage().contains("[truncated]"));
+        }
+    }
+
+    @Test
     public void comment() throws IOException {
         StringBuilder toml = new StringBuilder("# ");
         for (int i = 0; i < SCALE; i++) {


### PR DESCRIPTION
The TOML `parseIntFromBuffer` decimal branch already routes the literal length through `StreamReadConstraints.validateIntegerLength` before falling back to `NumberInput.parseBigInteger`. The three radix-prefixed branches (`0x`, `0o`, `0b`) call `NumberInput.parseBigIntegerWithRadix` directly without that check, so configuring `maxNumberLength` does not constrain radix literals the way it does decimal ones.

This change applies `validateIntegerLength` once at the top of the radix branch, covering all three variants while leaving existing parsing logic unchanged. Error reporting reuses the same `[truncated]` shape as the decimal path.

Regression coverage added in `LongTokenTest` for each of the three prefixes against the default `TomlFactory` (max number length 1000).

2.x → 3.x backport left to maintainers.