### PR TITLE
Restore `validateIntegerLength()` check in `_decodeBigInt`

### DIFF
--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -810,6 +810,7 @@ public class YAMLParser extends ParserBase
     }
 
     private BigInteger _decodeBigInt(String numStr, int base) throws JacksonException {
+        streamReadConstraints().validateIntegerLength(numStr.length());
         try {
             return base == 10 ?
                     NumberInput.parseBigInteger(numStr, isEnabled(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER)) :

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/IntegerLengthRadixTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/IntegerLengthRadixTest.java
@@ -38,7 +38,8 @@ public class IntegerLengthRadixTest extends ModuleTestBase
             MAPPER.readTree(doc);
             fail("expected StreamConstraintsException for decimal literal");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "Number");
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
         }
     }
 
@@ -51,7 +52,8 @@ public class IntegerLengthRadixTest extends ModuleTestBase
             MAPPER.readTree(doc);
             fail("expected StreamConstraintsException for hex literal");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "Number");
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
         }
     }
 
@@ -64,7 +66,8 @@ public class IntegerLengthRadixTest extends ModuleTestBase
             MAPPER.readTree(doc);
             fail("expected StreamConstraintsException for octal literal");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "Number");
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
         }
     }
 
@@ -77,7 +80,8 @@ public class IntegerLengthRadixTest extends ModuleTestBase
             MAPPER.readTree(doc);
             fail("expected StreamConstraintsException for binary literal");
         } catch (StreamConstraintsException e) {
-            verifyException(e, "Number");
+            verifyException(e, "Number value length");
+            verifyException(e, "exceeds the maximum allowed");
         }
     }
 }

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/IntegerLengthRadixTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/IntegerLengthRadixTest.java
@@ -1,0 +1,83 @@
+package tools.jackson.dataformat.yaml.constraints;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+import tools.jackson.dataformat.yaml.ModuleTestBase;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests that {@link StreamReadConstraints#validateIntegerLength(int)} is
+ * applied uniformly across the decimal and radix (hex / octal / binary)
+ * branches that ultimately route through {@code _decodeBigInt}.
+ */
+public class IntegerLengthRadixTest extends ModuleTestBase
+{
+    private final static int MAX_NUM_LEN = 1000;
+
+    private final YAMLMapper MAPPER = new YAMLMapper(
+            YAMLFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxNumberLength(MAX_NUM_LEN)
+                    .build())
+                .build());
+
+    // Sanity check: decimal path is already covered by the upstream check,
+    // so it should reject literals longer than the configured cap.
+    @Test
+    public void testDecimalIntegerLengthLimit() throws Exception
+    {
+        final String digits = "9".repeat(MAX_NUM_LEN + 10);
+        final String doc = "n: !!int " + digits + "\n";
+        try {
+            MAPPER.readTree(doc);
+            fail("expected StreamConstraintsException for decimal literal");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number");
+        }
+    }
+
+    @Test
+    public void testHexIntegerLengthLimit() throws Exception
+    {
+        final String digits = "f".repeat(MAX_NUM_LEN + 10);
+        final String doc = "n: !!int 0x" + digits + "\n";
+        try {
+            MAPPER.readTree(doc);
+            fail("expected StreamConstraintsException for hex literal");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number");
+        }
+    }
+
+    @Test
+    public void testOctalIntegerLengthLimit() throws Exception
+    {
+        final String digits = "7".repeat(MAX_NUM_LEN + 10);
+        final String doc = "n: !!int 0o" + digits + "\n";
+        try {
+            MAPPER.readTree(doc);
+            fail("expected StreamConstraintsException for octal literal");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number");
+        }
+    }
+
+    @Test
+    public void testBinaryIntegerLengthLimit() throws Exception
+    {
+        final String digits = "1".repeat(MAX_NUM_LEN + 10);
+        final String doc = "n: !!int 0b" + digits + "\n";
+        try {
+            MAPPER.readTree(doc);
+            fail("expected StreamConstraintsException for binary literal");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Number");
+        }
+    }
+}


### PR DESCRIPTION
On the 3.x branch, `YAMLParser._decodeBigInt` routes its input string straight to `NumberInput.parseBigInteger` / `parseBigIntegerWithRadix` without first running it through `StreamReadConstraints.validateIntegerLength`. The configured `maxNumberLength` cap therefore does not constrain integer literals that exit through this helper, including hex / octal / binary `!!int` radix scalars and any decimal scalar long enough to fall through to it.

This change adds the length check at the top of the method, mirroring the 2.x implementation and the surrounding number-validation helpers (`_cleanYamlInt`, `_cleanYamlFloat`) in the same file.

Regression coverage added in `IntegerLengthRadixTest` for decimal, hex, octal, and binary `!!int` literals against a `YAMLFactory` configured with `maxNumberLength(1000)`. Three of the four cases fail before the patch and pass after; the decimal one already passed via the existing `_cleanYamlInt` check and is included as a sanity guard.

2.x already has this check, so no backport is needed.