### PR TITLE
Clarify TOML array table comment

### DIFF
--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlParser.java
@@ -176,9 +176,8 @@ class TomlParser {
                 /* "Any reference to an array of tables points to the most recently defined table element of the array.
                  * This allows you to define sub-tables, and even sub-arrays of tables, inside the most recent table."
                  *
-                 * I interpret this somewhat broadly: I accept such references even if there were unrelated tables
-                 * in between, and I accept them for simple dotted keys as well (not just for tables). These cases don't
-                 * seem to be covered by the specification.
+                 * I interpret this somewhat broadly for table headers: I accept such references even if there were
+                 * unrelated tables in between. This case doesn't seem to be covered by the specification.
                  */
                 TomlArrayNode array = (TomlArrayNode) existing;
                 if (array.closed) {


### PR DESCRIPTION
## Summary
- clarify the TOML parser comment for array-of-tables traversal
- remove the stale claim that simple dotted-key assignments into arrays of tables are accepted
- leave parser behavior unchanged

## Verification
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk MAVEN_USER_HOME=/home/opc/dev/agent-work/toml329/.m2-jackson ./mvnw -pl toml -am test -q`
- `git diff --check`