### PR TITLE
Add release notes for TOML non-finite float fix

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -313,3 +313,15 @@ Dmitry Bufistov (@dmitry-workato)
 * Requested #601: (csv) Reader should allow separating plain `nullValue`
   and quoted value `"nullValue"`
  (2.22.0)
+
+EverNife (@EverNife)
+
+* Reported #696: (toml) Write non-finite floating-point values as TOML tokens
+  (`nan`/`inf`/`-inf`) instead of Java tokens (`NaN`/`Infinity`)
+ (2.23.0)
+
+seonwoojung (@seonwooj0810)
+
+* Fixed #696: (toml) Write non-finite floating-point values as TOML tokens
+  (`nan`/`inf`/`-inf`) instead of Java tokens (`NaN`/`Infinity`)
+ (2.23.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,10 @@ Active Maintainers:
 
 2.23.0 (not yet released)
 
-No changes since 2.22
+#696: (toml) Write non-finite floating-point values as TOML tokens
+  (`nan`/`inf`/`-inf`) instead of Java tokens (`NaN`/`Infinity`)
+ (reported by @EverNife)
+ (fix by @seonwooj0810)
 
 2.22.0 (31-May-2026)
 


### PR DESCRIPTION
Adds the release note and credits entries for the TOML non-finite floating-point writer fix from #697 / #696.

Changes:
- Add #696 entry under `2.23.0 (not yet released)` in `release-notes/VERSION-2.x`
- Add reporter and fixer entries in `release-notes/CREDITS-2.x`

Verification:
- `git diff --check HEAD~1..HEAD`