### PR TITLE
Expand TOML dotted key nesting checks [CVE-2026-85278]

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,11 @@ Active Maintainers:
 === Releases ===
 ------------------------------------------------------------------------
 
+2.18.10 (not yet released)
+
+#702: (toml) Expand nesting depth checks for dotted keys
+ (contributed by @yawkat)
+
 2.18.9 (07-Jul-2026)
 
 No changes since 2.18.8

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -56,9 +56,7 @@ class Parser {
         Parser parser = new Parser(new TomlFactory(), ioContext,
                 new TomlStreamReadException.ErrorContext(ioContext.contentReference(), null), options, reader);
         try {
-            final ObjectNode node = parser.parse();
-            assert parser.getNestingDepth() == 0;
-            return node;
+            return parser.parse();
         } finally {
             parser.lexer.releaseBuffers();
         }
@@ -82,16 +80,10 @@ class Parser {
                 new TomlStreamReadException.ErrorContext(ioContext.contentReference(), null),
                 factory.getFormatParserFeatures(), reader);
         try {
-            final ObjectNode node = parser.parse();
-            assert parser.getNestingDepth() == 0;
-            return node;
+            return parser.parse();
         } finally {
             parser.lexer.releaseBuffers();
         }
-    }
-
-    int getNestingDepth() {
-        return lexer.getNestingDepth();
     }
 
     private TomlToken peek() throws TomlStreamReadException {
@@ -120,14 +112,16 @@ class Parser {
     public ObjectNode parse() throws IOException {
         TomlObjectNode root = (TomlObjectNode) factory.objectNode();
         TomlObjectNode currentTable = root;
+        int currentTableDepth = 1;
         while (next != null) {
             TomlToken token = peek();
             if (token == TomlToken.UNQUOTED_KEY || token == TomlToken.STRING) {
-                parseKeyVal(currentTable, Lexer.EXPECT_EOL);
+                parseKeyVal(currentTable, Lexer.EXPECT_EOL, currentTableDepth);
             } else if (token == TomlToken.STD_TABLE_OPEN) {
                 pollExpected(TomlToken.STD_TABLE_OPEN, Lexer.EXPECT_INLINE_KEY);
-                FieldRef fieldRef = parseAndEnterKey(root, true);
-                currentTable = getOrCreateObject(fieldRef.object, fieldRef.key);
+                FieldRef fieldRef = parseAndEnterKey(root, true, 1);
+                currentTableDepth = fieldRef.objectDepth + 1;
+                currentTable = getOrCreateObject(fieldRef.object, fieldRef.key, currentTableDepth);
                 if (currentTable.defined) {
                     throw errorContext.atPosition(lexer).generic("Table redefined");
                 }
@@ -135,11 +129,14 @@ class Parser {
                 pollExpected(TomlToken.STD_TABLE_CLOSE, Lexer.EXPECT_EOL);
             } else if (token == TomlToken.ARRAY_TABLE_OPEN) {
                 pollExpected(TomlToken.ARRAY_TABLE_OPEN, Lexer.EXPECT_INLINE_KEY);
-                FieldRef fieldRef = parseAndEnterKey(root, true);
-                TomlArrayNode array = getOrCreateArray(fieldRef.object, fieldRef.key);
+                FieldRef fieldRef = parseAndEnterKey(root, true, 1);
+                int arrayDepth = fieldRef.objectDepth + 1;
+                TomlArrayNode array = getOrCreateArray(fieldRef.object, fieldRef.key, arrayDepth);
                 if (array.closed) {
                     throw errorContext.atPosition(lexer).generic("Array already finished");
                 }
+                currentTableDepth = arrayDepth + 1;
+                tomlFactory.streamReadConstraints().validateNestingDepth(currentTableDepth);
                 currentTable = (TomlObjectNode) array.addObject();
                 pollExpected(TomlToken.ARRAY_TABLE_CLOSE, Lexer.EXPECT_EOL);
             } else {
@@ -156,9 +153,11 @@ class Parser {
 
     private FieldRef parseAndEnterKey(
             TomlObjectNode outer,
-            boolean forTable
+            boolean forTable,
+            int outerDepth
     ) throws IOException {
         TomlObjectNode node = outer;
+        int nodeDepth = outerDepth;
         while (true) {
             if (node.closed) {
                 throw errorContext.atPosition(lexer).generic("Object already closed");
@@ -180,15 +179,20 @@ class Parser {
             }
             pollExpected(partToken, Lexer.EXPECT_INLINE_KEY);
             if (peek() != TomlToken.DOT_SEP) {
-                return new FieldRef(node, part);
+                return new FieldRef(node, part, nodeDepth);
             }
             pollExpected(TomlToken.DOT_SEP, Lexer.EXPECT_INLINE_KEY);
+
+            int childDepth = nodeDepth + 1;
+            tomlFactory.streamReadConstraints().validateNestingDepth(childDepth);
 
             JsonNode existing = node.get(part);
             if (existing == null) {
                 node = (TomlObjectNode) node.putObject(part);
+                nodeDepth = childDepth;
             } else if (existing.isObject()) {
                 node = (TomlObjectNode) existing;
+                nodeDepth = childDepth;
             } else if (existing.isArray()) {
                 /* "Any reference to an array of tables points to the most recently defined table element of the array.
                  * This allows you to define sub-tables, and even sub-arrays of tables, inside the most recent table."
@@ -202,14 +206,17 @@ class Parser {
                     throw errorContext.atPosition(lexer).generic("Array already closed");
                 }
                 // Only arrays declared by array tables are not closed, and those are always arrays of objects.
+                int tableDepth = childDepth + 1;
+                tomlFactory.streamReadConstraints().validateNestingDepth(tableDepth);
                 node = (TomlObjectNode) array.get(array.size() - 1);
+                nodeDepth = tableDepth;
             } else {
                 throw errorContext.atPosition(lexer).generic("Path into existing non-object value of type " + existing.getNodeType());
             }
         }
     }
 
-    private JsonNode parseValue(int nextState) throws IOException {
+    private JsonNode parseValue(int nextState, int valueDepth) throws IOException {
         TomlToken firstToken = peek();
         switch (firstToken) {
             case STRING:
@@ -232,9 +239,11 @@ class Parser {
             case INTEGER:
                 return parseInt(nextState);
             case ARRAY_OPEN:
-                return parseArray(nextState);
+                tomlFactory.streamReadConstraints().validateNestingDepth(valueDepth);
+                return parseArray(nextState, valueDepth);
             case INLINE_TABLE_OPEN:
-                return parseInlineTable(nextState);
+                tomlFactory.streamReadConstraints().validateNestingDepth(valueDepth);
+                return parseInlineTable(nextState, valueDepth);
             default:
                 throw errorContext.atPosition(lexer).unexpectedToken(firstToken, "value");
         }
@@ -415,7 +424,7 @@ class Parser {
         }
     }
 
-    private ObjectNode parseInlineTable(int nextState) throws IOException {
+    private ObjectNode parseInlineTable(int nextState, int tableDepth) throws IOException {
         // inline-table = inline-table-open [ inline-table-keyvals ] inline-table-close
         // inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
         pollExpected(TomlToken.INLINE_TABLE_OPEN, Lexer.EXPECT_INLINE_KEY);
@@ -431,7 +440,7 @@ class Parser {
                     throw errorContext.atPosition(lexer).generic("Trailing comma not permitted for inline tables");
                 }
             }
-            parseKeyVal(node, Lexer.EXPECT_TABLE_SEP);
+            parseKeyVal(node, Lexer.EXPECT_TABLE_SEP, tableDepth);
             TomlToken sepToken = peek();
             if (sepToken == TomlToken.INLINE_TABLE_CLOSE) {
                 break;
@@ -447,7 +456,7 @@ class Parser {
         return node;
     }
 
-    private ArrayNode parseArray(int nextState) throws IOException {
+    private ArrayNode parseArray(int nextState, int arrayDepth) throws IOException {
         // array = array-open [ array-values ] ws-comment-newline array-close
         // array-values =  ws-comment-newline val ws-comment-newline array-sep array-values
         // array-values =/ ws-comment-newline val ws-comment-newline [ array-sep ]
@@ -458,7 +467,7 @@ class Parser {
             if (token == TomlToken.ARRAY_CLOSE) {
                 break;
             }
-            JsonNode value = parseValue(Lexer.EXPECT_ARRAY_SEP);
+            JsonNode value = parseValue(Lexer.EXPECT_ARRAY_SEP, arrayDepth + 1);
             node.add(value);
             TomlToken sepToken = peek();
             if (sepToken == TomlToken.ARRAY_CLOSE) {
@@ -474,18 +483,19 @@ class Parser {
         return node;
     }
 
-    private void parseKeyVal(TomlObjectNode target, int nextState) throws IOException {
+    private void parseKeyVal(TomlObjectNode target, int nextState, int targetDepth) throws IOException {
         // keyval = key keyval-sep val
-        FieldRef fieldRef = parseAndEnterKey(target, false);
+        FieldRef fieldRef = parseAndEnterKey(target, false, targetDepth);
         pollExpected(TomlToken.KEY_VAL_SEP, Lexer.EXPECT_VALUE);
-        JsonNode value = parseValue(nextState);
+        JsonNode value = parseValue(nextState, fieldRef.objectDepth + 1);
         if (fieldRef.object.has(fieldRef.key)) {
             throw errorContext.atPosition(lexer).generic("Duplicate key");
         }
         fieldRef.object.set(fieldRef.key, value);
     }
 
-    private TomlObjectNode getOrCreateObject(ObjectNode node, String field) throws TomlStreamReadException {
+    private TomlObjectNode getOrCreateObject(ObjectNode node, String field, int childDepth) throws IOException {
+        tomlFactory.streamReadConstraints().validateNestingDepth(childDepth);
         JsonNode existing = node.get(field);
         if (existing == null) {
             return (TomlObjectNode) node.putObject(field);
@@ -496,7 +506,8 @@ class Parser {
         }
     }
 
-    private TomlArrayNode getOrCreateArray(ObjectNode node, String field) throws TomlStreamReadException {
+    private TomlArrayNode getOrCreateArray(ObjectNode node, String field, int childDepth) throws IOException {
+        tomlFactory.streamReadConstraints().validateNestingDepth(childDepth);
         JsonNode existing = node.get(field);
         if (existing == null) {
             return (TomlArrayNode) node.putArray(field);
@@ -510,10 +521,12 @@ class Parser {
     private static class FieldRef {
         final TomlObjectNode object;
         final String key;
+        final int objectDepth;
 
-        FieldRef(TomlObjectNode object, String key) {
+        FieldRef(TomlObjectNode object, String key, int objectDepth) {
             this.object = object;
             this.key = key;
+            this.objectDepth = objectDepth;
         }
     }
 

--- a/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
+++ b/toml/src/main/java/com/fasterxml/jackson/dataformat/toml/Parser.java
@@ -514,7 +514,7 @@ class Parser {
         } else if (existing.isArray()) {
             return (TomlArrayNode) existing;
         } else {
-            throw errorContext.atPosition(lexer).generic("Path into existing non-array value of type " + node.getNodeType());
+            throw errorContext.atPosition(lexer).generic("Path into existing non-array value of type " + existing.getNodeType());
         }
     }
 

--- a/toml/src/main/jflex/com/fasterxml/jackson/dataformat/toml/toml.jflex
+++ b/toml/src/main/jflex/com/fasterxml/jackson/dataformat/toml/toml.jflex
@@ -15,7 +15,6 @@ package com.fasterxml.jackson.dataformat.toml;
 
 %init{
 this.ioContext = ioContext;
-this.streamReadConstraints = ioContext.streamReadConstraints();
 this.errorContext = errorContext;
 yybegin(EXPECT_EXPRESSION);
 this.zzBuffer = ioContext.allocTokenBuffer();
@@ -31,8 +30,6 @@ this.textBuffer = ioContext.constructReadConstrainedTextBuffer();
 
   private boolean trimmedNewline;
   final com.fasterxml.jackson.core.util.TextBuffer textBuffer;
-  private final com.fasterxml.jackson.core.StreamReadConstraints streamReadConstraints;
-  private int nestingDepth;
 
   private void requestLargerBuffer() throws TomlStreamReadException {
       if (prohibitInternalBufferAllocate) {
@@ -55,10 +52,6 @@ this.textBuffer = ioContext.constructReadConstrainedTextBuffer();
           zzBuffer = null;
       }
       textBuffer.releaseBuffers();
-  }
-
-  public int getNestingDepth() {
-      return nestingDepth;
   }
 
   private void startString() {
@@ -264,14 +257,8 @@ HexDig = [0-9A-Fa-f]
           yybegin(LITERAL_STRING);
           startString();
       }
-    {StdTableOpen} {
-          streamReadConstraints.validateNestingDepth(++nestingDepth);
-          return TomlToken.STD_TABLE_OPEN;
-      }
-    {ArrayTableOpen} {
-          streamReadConstraints.validateNestingDepth(++nestingDepth);
-          return TomlToken.ARRAY_TABLE_OPEN;
-      }
+    {StdTableOpen} {return TomlToken.STD_TABLE_OPEN;}
+    {ArrayTableOpen} {return TomlToken.ARRAY_TABLE_OPEN;}
     {KeyValSep} {return TomlToken.KEY_VAL_SEP;}
     {NewLine} {}
     {Comment} {}
@@ -297,18 +284,9 @@ HexDig = [0-9A-Fa-f]
           startString();
       }
     {KeyValSep} {return TomlToken.KEY_VAL_SEP;}
-    {InlineTableClose} {
-          nestingDepth--;
-          return TomlToken.INLINE_TABLE_CLOSE;
-      }
-    {StdTableClose} {
-          nestingDepth--;
-          return TomlToken.STD_TABLE_CLOSE;
-      }
-    {ArrayTableClose} {
-          nestingDepth--;
-          return TomlToken.ARRAY_TABLE_CLOSE;
-      }
+    {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
+    {StdTableClose} {return TomlToken.STD_TABLE_CLOSE;}
+    {ArrayTableClose} {return TomlToken.ARRAY_TABLE_CLOSE;}
 }
 
 <EXPECT_EOL> {
@@ -362,30 +340,18 @@ HexDig = [0-9A-Fa-f]
       }
 
     // inline array / table
-    {ArrayOpen} {WsCommentNewlineNonEmpty}* {
-          streamReadConstraints.validateNestingDepth(++nestingDepth);
-          return TomlToken.ARRAY_OPEN;
-      }
-    {InlineTableOpen} {
-          streamReadConstraints.validateNestingDepth(++nestingDepth);
-          return TomlToken.INLINE_TABLE_OPEN;
-      }
+    {ArrayOpen} {WsCommentNewlineNonEmpty}* {return TomlToken.ARRAY_OPEN;}
+    {InlineTableOpen} {return TomlToken.INLINE_TABLE_OPEN;}
 
     // array end just after comma
-    {WsCommentNewlineNonEmpty}* {ArrayClose} {
-          nestingDepth--;
-          return TomlToken.ARRAY_CLOSE;
-      }
+    {WsCommentNewlineNonEmpty}* {ArrayClose} {return TomlToken.ARRAY_CLOSE;}
 }
 
 <EXPECT_ARRAY_SEP> {
     // array-values =  ws-comment-newline val ws-comment-newline array-sep array-values
     // array-values =/ ws-comment-newline val ws-comment-newline [ array-sep ]
     {Comma} {WsCommentNewlineNonEmpty}* {return TomlToken.COMMA;}
-    {ArrayClose} {
-          nestingDepth--;
-          return TomlToken.ARRAY_CLOSE;
-      }
+    {ArrayClose} {return TomlToken.ARRAY_CLOSE;}
     {WsCommentNewlineNonEmpty} {} // always allowed here
 }
 
@@ -394,10 +360,7 @@ HexDig = [0-9A-Fa-f]
     // inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
 
     {Ws} {Comma} {Ws} {return TomlToken.COMMA;}
-    {InlineTableClose} {
-          nestingDepth--;
-          return TomlToken.INLINE_TABLE_CLOSE;
-      }
+    {InlineTableClose} {return TomlToken.INLINE_TABLE_CLOSE;}
 }
 
 <BASIC_STRING> {

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/TomlParserTest.java
@@ -1,5 +1,7 @@
 package com.fasterxml.jackson.dataformat.toml;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +42,17 @@ public class TomlParserTest extends TomlMapperTestBase {
                 factory, testIOContext(),
                 new StringReader(toml)
         );
+    }
+
+    private static void assertNestingDepthExceeded(TomlFactory factory,
+            @Language("toml") String toml) throws Exception {
+        try {
+            toml(factory, toml);
+            Assert.fail("Should not pass");
+        } catch (StreamConstraintsException e) {
+            Assert.assertTrue("unexpected exception message: " + e.getMessage(),
+                    e.getMessage().contains("Document nesting depth (4) exceeds the maximum allowed (3"));
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -130,6 +143,79 @@ public class TomlParserTest extends TomlMapperTestBase {
                         "physical.color = \"orange\"\n" +
                         "physical.shape = \"round\"\n" +
                         "site.\"google.com\" = true"));
+    }
+
+    @Test
+    public void dottedKeysRespectMaxNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        Assert.assertEquals(json("{\"a\":{\"b\":{\"c\":1}}}"),
+                toml(factory, "a.b.c = 1"));
+
+        assertNestingDepthExceeded(factory, "a.b.c.d = 1");
+    }
+
+    @Test
+    public void dottedKeysRespectCurrentTableNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        Assert.assertEquals(json("{\"a\":{\"b\":{\"c\":1}}}"),
+                toml(factory, "[a.b]\nc = 1"));
+
+        assertNestingDepthExceeded(factory, "[a.b]\nc.d = 1");
+        assertNestingDepthExceeded(factory, "[a.b.c]\nd = 1");
+    }
+
+    @Test
+    public void dottedKeysRespectExistingObjectNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        Assert.assertEquals(json("{\"a\":{\"b\":{\"c\":1,\"d\":2}}}"),
+                toml(factory, "a.b.c = 1\na.b.d = 2"));
+
+        assertNestingDepthExceeded(factory, "a.b.c = 1\na.b.d.e = 2");
+    }
+
+    @Test
+    public void inlineContainersRespectDottedKeyNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        Assert.assertEquals(json("{\"a\":{\"b\":{\"c\":1}}}"),
+                toml(factory, "a.b = { c = 1 }"));
+
+        assertNestingDepthExceeded(factory, "a.b.c = {}");
+        assertNestingDepthExceeded(factory, "a.b = { c = {} }");
+        assertNestingDepthExceeded(factory, "a.b = [[1]]");
+    }
+
+    @Test
+    public void arrayTablesRespectMaxNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        Assert.assertEquals(json("{\"a\":[{\"b\":1}]}"),
+                toml(factory, "[[a]]\nb = 1"));
+
+        assertNestingDepthExceeded(factory, "[[a.b]]\nc = 1");
     }
 
     @Test

--- a/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/TomlParserTest.java
+++ b/toml/src/test/java/com/fasterxml/jackson/dataformat/toml/TomlParserTest.java
@@ -219,6 +219,23 @@ public class TomlParserTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void dottedKeysIntoArrayTableRespectMaxNestingDepth() throws Exception {
+        TomlFactory factory = TomlFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxNestingDepth(3)
+                        .build())
+                .build();
+
+        // Navigating a table path through an existing array table points at its most
+        // recently defined element; the created sub-table must still be depth-counted.
+        Assert.assertEquals(json("{\"a\":[{\"b\":{\"c\":1}}]}"),
+                toml("[[a]]\n[a.b]\nc = 1"));
+
+        assertNestingDepthExceeded(factory, "[[a]]\n[a.b]\nc = 1");
+        assertNestingDepthExceeded(factory, "[[a]]\n[[a.b]]\nc = 1");
+    }
+
+    @Test
     public void dottedKeysWhitespace() throws Exception {
         Assert.assertEquals(
                 json("{\"fruit\": {\"name\": \"banana\", \"color\": \"yellow\", \"flavor\": \"banana\"}}"),


### PR DESCRIPTION
## Summary
- Expand TOML nesting-depth tracking to include semantic depth from dotted keys and table paths
- Use parser-level depth propagation for dotted keys, table headers, array tables, inline tables, and inline arrays
- Add regression coverage for dotted keys, current tables, array tables, and inline containers
- Add a 2.18 release note entry

## Tests
- `./mvnw -pl toml clean -Dtest=TomlParserTest,FuzzTomlReadTest test`
- `./mvnw -pl toml test`

## Related

* https://github.com/FasterXML/jackson-dataformats-text/security/advisories/GHSA-7vh9-hpf2-3qw2
