### PR TITLE
Add name-based column modification to `CsvSchema.Builder` (#699)

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -915,8 +915,11 @@ public class CsvSchema
         }
 
         /**
-         * Helper method for finding index of the column with given name; throws
-         * {@link IllegalArgumentException} if no column with the name exists.
+         * Helper method for finding index of the column with given name.
+         *
+         * @param name Name of the column to find
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
          *
          * @since 2.23
          */

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -630,6 +630,39 @@ public class CsvSchema
         }
 
         /**
+         * Method for renaming an existing column, located by its current name
+         * instead of by index. If no column with given {@code oldName} exists,
+         * an {@link IllegalArgumentException} is thrown.
+         *
+         * @since 2.23
+         */
+        public Builder renameColumn(String oldName, String newName) {
+            return renameColumn(_columnIndex(oldName), newName);
+        }
+
+        /**
+         * Method for replacing an existing column, located by its current name
+         * instead of by index. If no column with given {@code name} exists,
+         * an {@link IllegalArgumentException} is thrown.
+         *
+         * @since 2.23
+         */
+        public Builder replaceColumn(String name, Column c) {
+            return replaceColumn(_columnIndex(name), c);
+        }
+
+        /**
+         * Method for removing an existing column, located by its name instead
+         * of by index. If no column with given {@code name} exists, an
+         * {@link IllegalArgumentException} is thrown.
+         *
+         * @since 2.23
+         */
+        public Builder removeColumn(String name) {
+            return removeColumn(_columnIndex(name));
+        }
+
+        /**
          * Helper method called to drop the last collected column name if
          * it is empty: called if {link CsvParser.Feature#ALLOW_TRAILING_COMMA}
          * enabled to remove the last entry after being added initially.
@@ -868,6 +901,21 @@ public class CsvSchema
             if (index < 0 || index >= _columns.size()) {
                 throw new IllegalArgumentException("Illegal index "+index+"; only got "+_columns.size()+" columns");
             }
+        }
+
+        /**
+         * Helper method for finding index of the column with given name; throws
+         * {@link IllegalArgumentException} if no column with the name exists.
+         *
+         * @since 2.23
+         */
+        protected int _columnIndex(String name) {
+            for (int i = 0, end = _columns.size(); i < end; ++i) {
+                if (_columns.get(i).getName().equals(name)) {
+                    return i;
+                }
+            }
+            throw new IllegalArgumentException("No column with name '"+name+"' (have "+_columns.size()+" columns)");
         }
     }
 

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -647,6 +647,11 @@ public class CsvSchema
         /**
          * Method for replacing an existing column, located by its current name
          * instead of by index.
+         *<p>
+         * NOTE: index of the replacement column {@code c} is ignored (as with
+         * {@link #replaceColumn(int, Column)}): columns are renumbered to match
+         * their actual position when {@link #build()} is called. Caller hence does
+         * not need to know index of the column being replaced.
          *
          * @param name Name of the column to replace
          * @param c Column definition to use as replacement
@@ -695,10 +700,39 @@ public class CsvSchema
             return this;
         }
 
+        /**
+         * Method for changing type of an existing column, located by its name
+         * instead of by index.
+         *
+         * @param name Name of the column to change type of
+         * @param type Type to assign to the column
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
+         *
+         * @since 2.23
+         */
+        public Builder setColumnType(String name, ColumnType type) {
+            return setColumnType(_columnIndex(name), type);
+        }
+
         public Builder removeArrayElementSeparator(int index) {
             _checkIndex(index);
             _columns.set(index, _columns.get(index).withArrayElementSeparator(""));
             return this;
+        }
+
+        /**
+         * Method for removing array element separator of an existing column,
+         * located by its name instead of by index.
+         *
+         * @param name Name of the column to remove array element separator of
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
+         *
+         * @since 2.23
+         */
+        public Builder removeArrayElementSeparator(String name) {
+            return removeArrayElementSeparator(_columnIndex(name));
         }
 
         /**
@@ -708,6 +742,25 @@ public class CsvSchema
             _checkIndex(index);
             _columns.set(index, _columns.get(index).withArrayElementSeparator(sep));
             return this;
+        }
+
+        /**
+         * Method for setting array element separator of an existing column,
+         * located by its name instead of by index.
+         *<p>
+         * NOTE: not to be confused with single-argument
+         * {@link #setArrayElementSeparator(String)}, which sets the schema-wide
+         * default separator instead of that of a single column.
+         *
+         * @param name Name of the column to set array element separator of
+         * @param sep Array element separator to assign to the column
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
+         *
+         * @since 2.23
+         */
+        public Builder setArrayElementSeparator(String name, String sep) {
+            return setArrayElementSeparator(_columnIndex(name), sep);
         }
 
         public Builder setAnyPropertyName(String name) {
@@ -738,12 +791,31 @@ public class CsvSchema
          * @since 2.9
          */
         public boolean hasColumn(String name) {
+            return columnIndex(name) >= 0;
+        }
+
+        /**
+         * Method for finding index of the column with given name, if any.
+         *<p>
+         * NOTE: this method requires linear scan over existing columns
+         * so it may be more efficient to use other types of lookups if
+         * available (for example, {@link CsvSchema#columnIndex(String)} has a
+         * hash lookup to use).
+         *
+         * @param name Name of column to find
+         *
+         * @return Index of the first column with given name, if one exists;
+         *    {@code -1} if not
+         *
+         * @since 2.23
+         */
+        public int columnIndex(String name) {
             for (int i = 0, end = _columns.size(); i < end; ++i) {
                 if (_columns.get(i).getName().equals(name)) {
-                    return true;
+                    return i;
                 }
             }
-            return false;
+            return -1;
         }
 
         /**
@@ -915,21 +987,39 @@ public class CsvSchema
         }
 
         /**
-         * Helper method for finding index of the column with given name.
+         * Helper method for finding index of the column with given name, for
+         * use by name-based mutators; same as {@link #columnIndex(String)} except
+         * that a missing column is reported as an exception instead of {@code -1}.
          *
          * @param name Name of the column to find
+         *
+         * @return Index of the first column with given name
          *
          * @throws IllegalArgumentException if no column with given {@code name} exists
          *
          * @since 2.23
          */
         protected int _columnIndex(String name) {
-            for (int i = 0, end = _columns.size(); i < end; ++i) {
-                if (_columns.get(i).getName().equals(name)) {
-                    return i;
-                }
+            int ix = columnIndex(name);
+            if (ix < 0) {
+                throw new IllegalArgumentException("No column '"+name+"' in CsvSchema.Builder (known columns: "
+                        +_columnNames()+")");
             }
-            throw new IllegalArgumentException("No column with name '"+name+"' (have "+_columns.size()+" columns)");
+            return ix;
+        }
+
+        /**
+         * Helper method for constructing List of names of currently included
+         * columns, for use in exception messages.
+         *
+         * @since 2.23
+         */
+        private List<String> _columnNames() {
+            List<String> names = new ArrayList<>(_columns.size());
+            for (int i = 0, end = _columns.size(); i < end; ++i) {
+                names.add(_columns.get(i).getName());
+            }
+            return names;
         }
     }
 

--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -631,8 +631,12 @@ public class CsvSchema
 
         /**
          * Method for renaming an existing column, located by its current name
-         * instead of by index. If no column with given {@code oldName} exists,
-         * an {@link IllegalArgumentException} is thrown.
+         * instead of by index.
+         *
+         * @param oldName Current name of the column to rename
+         * @param newName New name to assign to the column
+         *
+         * @throws IllegalArgumentException if no column with given {@code oldName} exists
          *
          * @since 2.23
          */
@@ -642,8 +646,12 @@ public class CsvSchema
 
         /**
          * Method for replacing an existing column, located by its current name
-         * instead of by index. If no column with given {@code name} exists,
-         * an {@link IllegalArgumentException} is thrown.
+         * instead of by index.
+         *
+         * @param name Name of the column to replace
+         * @param c Column definition to use as replacement
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
          *
          * @since 2.23
          */
@@ -653,8 +661,11 @@ public class CsvSchema
 
         /**
          * Method for removing an existing column, located by its name instead
-         * of by index. If no column with given {@code name} exists, an
-         * {@link IllegalArgumentException} is thrown.
+         * of by index.
+         *
+         * @param name Name of the column to remove
+         *
+         * @throws IllegalArgumentException if no column with given {@code name} exists
          *
          * @since 2.23
          */

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -253,4 +253,46 @@ public class CsvSchemaTest extends ModuleTestBase
 
         _verifyLinks(pointSchema);
     }
+
+    // For [dataformats-text#699]: modify columns in Builder by name
+    @Test
+    public void testModifyColumnsByName()
+    {
+        CsvSchema.Builder b = CsvSchema.builder()
+                .addColumn("a", CsvSchema.ColumnType.STRING)
+                .addColumn("b", CsvSchema.ColumnType.NUMBER)
+                .addColumn("c", CsvSchema.ColumnType.BOOLEAN);
+
+        // rename by name maps to same slot as rename by index
+        b.renameColumn("b", "b2");
+        // replace by name preserves position, changes type
+        b.replaceColumn("c", new Column(2, "c2", CsvSchema.ColumnType.STRING));
+
+        CsvSchema schema = b.build();
+        assertEquals(3, schema.size());
+        assertEquals("a", schema.column(0).getName());
+        assertEquals("b2", schema.column(1).getName());
+        assertEquals(CsvSchema.ColumnType.NUMBER, schema.column(1).getType());
+        assertEquals("c2", schema.column(2).getName());
+        assertEquals(CsvSchema.ColumnType.STRING, schema.column(2).getType());
+
+        // remove by name drops just that column
+        CsvSchema shrunk = schema.rebuild().removeColumn("a").build();
+        assertEquals(2, shrunk.size());
+        assertEquals("b2", shrunk.column(0).getName());
+        assertEquals("c2", shrunk.column(1).getName());
+    }
+
+    // For [dataformats-text#699]: unknown name should fail fast
+    @Test
+    public void testModifyUnknownColumnByName()
+    {
+        CsvSchema.Builder b = CsvSchema.builder().addColumn("a");
+        try {
+            b.removeColumn("missing");
+            fail("Should not pass");
+        } catch (IllegalArgumentException e) {
+            verifyException(e, "No column with name 'missing'");
+        }
+    }
 }

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -265,8 +265,10 @@ public class CsvSchemaTest extends ModuleTestBase
 
         // rename by name maps to same slot as rename by index
         b.renameColumn("b", "b2");
-        // replace by name preserves position, changes type
-        b.replaceColumn("c", new Column(2, "c2", CsvSchema.ColumnType.STRING));
+        // replace by name preserves position, changes type; note that index of
+        // the replacement Column is deliberately "wrong" (0, not 2) to verify it
+        // is ignored -- the whole point being caller need not know the index
+        b.replaceColumn("c", new Column(0, "c2", CsvSchema.ColumnType.STRING));
 
         CsvSchema schema = b.build();
         assertEquals(3, schema.size());
@@ -275,6 +277,9 @@ public class CsvSchemaTest extends ModuleTestBase
         assertEquals(CsvSchema.ColumnType.NUMBER, schema.column(1).getType());
         assertEquals("c2", schema.column(2).getName());
         assertEquals(CsvSchema.ColumnType.STRING, schema.column(2).getType());
+        // ... and index gets renumbered to match actual position
+        assertEquals(2, schema.column(2).getIndex());
+        assertEquals(2, schema.columnIndex("c2"));
 
         // remove by name drops just that column
         CsvSchema shrunk = schema.rebuild().removeColumn("a").build();
@@ -283,7 +288,41 @@ public class CsvSchemaTest extends ModuleTestBase
         assertEquals("c2", shrunk.column(1).getName());
     }
 
-    // For [dataformats-text#699]: unknown name should fail fast
+    // For [dataformats-text#699]: type and array-element-separator by name too
+    @Test
+    public void testModifyColumnSettingsByName()
+    {
+        CsvSchema.Builder b = CsvSchema.builder()
+                .addColumn("a", CsvSchema.ColumnType.STRING)
+                .addColumn("tags", CsvSchema.ColumnType.ARRAY);
+
+        b.setColumnType("a", CsvSchema.ColumnType.NUMBER);
+        b.setArrayElementSeparator("tags", ";");
+
+        CsvSchema schema = b.build();
+        assertEquals(CsvSchema.ColumnType.NUMBER, schema.column(0).getType());
+        assertEquals(";", schema.column(1).getArrayElementSeparator());
+
+        // and removal of separator, likewise by name
+        assertEquals("", schema.rebuild().removeArrayElementSeparator("tags")
+                .build().column(1).getArrayElementSeparator());
+    }
+
+    // For [dataformats-text#699]: non-throwing index lookup from Builder
+    @Test
+    public void testColumnIndexLookupFromBuilder()
+    {
+        CsvSchema.Builder b = CsvSchema.builder().addColumn("a").addColumn("b");
+        assertEquals(0, b.columnIndex("a"));
+        assertEquals(1, b.columnIndex("b"));
+        assertEquals(-1, b.columnIndex("missing"));
+        // and `hasColumn()` remains consistent with it
+        assertTrue(b.hasColumn("a"));
+        assertFalse(b.hasColumn("missing"));
+    }
+
+    // For [dataformats-text#699]: unknown name should fail fast, and the failure
+    // should name the columns that DO exist (as `CsvSchema.withColumn(String,...)` does)
     @Test
     public void testModifyUnknownColumnByName()
     {
@@ -292,7 +331,8 @@ public class CsvSchemaTest extends ModuleTestBase
             b.removeColumn("missing");
             fail("Should not pass");
         } catch (IllegalArgumentException e) {
-            verifyException(e, "No column with name 'missing'");
+            verifyException(e, "No column 'missing' in CsvSchema.Builder");
+            verifyException(e, "known columns: [a]");
         }
     }
 }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -337,3 +337,13 @@ seonwoojung (@seonwooj0810)
 * Fixed #696: (toml) Write non-finite floating-point values as TOML tokens
   (`nan`/`inf`/`-inf`) instead of Java tokens (`NaN`/`Infinity`)
  (2.23.0)
+
+James Howe (@OrangeDog)
+
+* Requested #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
+ (2.23.0)
+
+seonwoojung (@seonwooj0810)
+
+* Fixed #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
+ (2.23.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -20,6 +20,9 @@ Active Maintainers:
   (`nan`/`inf`/`-inf`) instead of Java tokens (`NaN`/`Infinity`)
  (reported by @EverNife)
  (fix by @seonwooj0810)
+#699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
+ (requested by @OrangeDog)
+ (fix by @seonwooj0810)
 
 2.22.2 (not yet released)
 


### PR DESCRIPTION
Fixes #699

`CsvSchema.Builder` only lets you modify columns by index (`renameColumn(int, ...)`, `replaceColumn(int, ...)`, `removeColumn(int)`), so modifying a column by *name* meant building the schema, scanning for the index, and rebuilding — and the index could shift in between. This adds name-based overloads so the fluent builder can locate a column by name directly.

## Changes
- `renameColumn(String oldName, String newName)`
- `replaceColumn(String name, Column c)`
- `removeColumn(String name)`

Each resolves the name to an index via a new `_columnIndex(String)` helper (linear scan, mirroring the existing `hasColumn(String)`) and delegates to the corresponding index-based method, so existing behavior is unchanged. An unknown name throws `IllegalArgumentException`, consistent with the existing `_checkIndex` out-of-range handling.

## Test evidence
Added to `CsvSchemaTest`:
- `testModifyColumnsByName` — rename/replace/remove by name preserve column positions and only touch the targeted column.
- `testModifyUnknownColumnByName` — an unknown name throws `IllegalArgumentException`.

`./mvnw -pl csv test -Dtest=CsvSchemaTest` → `Tests run: 11, Failures: 0, Errors: 0`.

Verification done: (1) no in-flight PR (searched open/all PRs for `CsvSchema renameColumn removeColumn`); (2) no self-claim (issue has no comments); (3) code-focused (`CsvSchema.java` + test); (4) confirmed the Builder had only index-based modifiers on `2.x`; (6) not a `spring-projects/*` repo, no triage gate.
