### PR TITLE
Fix #701: quote YAML 1.1 number-form Strings under ALWAYS_QUOTE_NUMBERS_AS_STRINGS

### DIFF
--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -307,3 +307,15 @@ Sergio Delgado (@serandel)
 * Reported #154: (yaml) YAML file with no content throws `MismatchedInputException`
   when binding to Object type (POJO etc)
  (2.21.0)
+
+Pétrus Pradella (@EverNife)
+
+* Reported #701: (yaml) `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` does not quote YAML 1.1
+  exponent (`1e5`), hex (`0x1F`) and underscore (`12_34`) number forms
+ (2.21.6)
+
+seonwoojung (@seonwooj0810)
+
+* Contributed fix for #701: (yaml) `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` does not quote
+  YAML 1.1 exponent (`1e5`), hex (`0x1F`) and underscore (`12_34`) number forms
+ (2.21.6)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,10 @@ Active Maintainers:
 
 2.21.6 (not yet released)
 
+#701: (yaml) `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` does not quote YAML 1.1 exponent
+  (`1e5`), hex (`0x1F`) and underscore (`12_34`) number forms
+ (reported by @EverNife)
+ (fix contributed by @seonwooj0810)
 #702: (toml) Expand nesting depth checks for dotted keys
  (contributed by @yawkat)
 

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -219,16 +219,6 @@ public class YAMLGenerator extends GeneratorBase
     protected final static long MIN_INT_AS_LONG = (long) Integer.MIN_VALUE;
     protected final static long MAX_INT_AS_LONG = (long) Integer.MAX_VALUE;
     protected final static Pattern PLAIN_NUMBER_P = Pattern.compile("[+-]?[0-9]*(\\.[0-9]*)?");
-
-    /**
-     * SnakeYAML's own implicit resolver patterns for {@code int} and {@code float}: used
-     * (in addition to {@link #PLAIN_NUMBER_P}) by {@link Feature#ALWAYS_QUOTE_NUMBERS_AS_STRINGS}
-     * to detect number-like Strings that {@link #PLAIN_NUMBER_P} misses -- notably YAML 1.1
-     * exponent ({@code 1e5}), hex ({@code 0x1F}) and underscore ({@code 12_34}) forms. Since these
-     * are the exact patterns the parser uses to resolve plain scalars back to numbers, quoting
-     * everything they match guarantees such Strings round-trip. See [dataformats-text#701].
-     */
-    protected final static Pattern[] NUMBER_RESOLVER_PS = { Resolver.INT, Resolver.FLOAT };
     protected final static String TAG_BINARY = Tag.BINARY.toString();
 
     /*
@@ -711,22 +701,33 @@ public class YAMLGenerator extends GeneratorBase
      * Checks whether given String value would be re-read as a YAML number if emitted
      * unquoted; used by {@link Feature#ALWAYS_QUOTE_NUMBERS_AS_STRINGS}. Combines the
      * historical {@link #PLAIN_NUMBER_P} check (retained for backwards compatibility)
-     * with SnakeYAML's own {@code int}/{@code float} resolver patterns, so that YAML 1.1
-     * exponent, hex and underscore number forms -- which {@link #PLAIN_NUMBER_P} does not
-     * match -- are quoted too and thus round-trip. See [dataformats-text#701].
+     * with SnakeYAML's own implicit resolver patterns for {@code int} and {@code float}
+     * ({@link Resolver#INT}, {@link Resolver#FLOAT}) -- the very patterns the parser uses
+     * to resolve plain scalars back to numbers -- so that YAML 1.1 exponent
+     * ({@code 1e5}), hex ({@code 0x1F}) and underscore ({@code 12_34}) forms, which
+     * {@link #PLAIN_NUMBER_P} does not match, are quoted too and thus round-trip.
+     * See [dataformats-text#701].
      *
-     * @since 2.23
+     * @since 2.21.6
      */
     protected boolean _looksLikeYAMLNumber(String text) {
-        if (PLAIN_NUMBER_P.matcher(text).matches()) {
-            return true;
+        // 23-Jul-2026, tatu: Regexps are relatively costly so avoid them for the
+        //    common case of "regular" text: all forms matched below have to start
+        //    with one of following characters
+        if (text.isEmpty()) {
+            return false;
         }
-        for (Pattern p : NUMBER_RESOLVER_PS) {
-            if (p.matcher(text).matches()) {
-                return true;
-            }
+        switch (text.charAt(0)) {
+        case '+': case '-': case '.':
+        case '0': case '1': case '2': case '3': case '4':
+        case '5': case '6': case '7': case '8': case '9':
+            break;
+        default:
+            return false;
         }
-        return false;
+        return PLAIN_NUMBER_P.matcher(text).matches()
+                || Resolver.INT.matcher(text).matches()
+                || Resolver.FLOAT.matcher(text).matches();
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -13,6 +13,7 @@ import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.emitter.Emitter;
 import org.yaml.snakeyaml.events.*;
 import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.GeneratorBase;
@@ -218,6 +219,16 @@ public class YAMLGenerator extends GeneratorBase
     protected final static long MIN_INT_AS_LONG = (long) Integer.MIN_VALUE;
     protected final static long MAX_INT_AS_LONG = (long) Integer.MAX_VALUE;
     protected final static Pattern PLAIN_NUMBER_P = Pattern.compile("[+-]?[0-9]*(\\.[0-9]*)?");
+
+    /**
+     * SnakeYAML's own implicit resolver patterns for {@code int} and {@code float}: used
+     * (in addition to {@link #PLAIN_NUMBER_P}) by {@link Feature#ALWAYS_QUOTE_NUMBERS_AS_STRINGS}
+     * to detect number-like Strings that {@link #PLAIN_NUMBER_P} misses -- notably YAML 1.1
+     * exponent ({@code 1e5}), hex ({@code 0x1F}) and underscore ({@code 12_34}) forms. Since these
+     * are the exact patterns the parser uses to resolve plain scalars back to numbers, quoting
+     * everything they match guarantees such Strings round-trip. See [dataformats-text#701].
+     */
+    protected final static Pattern[] NUMBER_RESOLVER_PS = { Resolver.INT, Resolver.FLOAT };
     protected final static String TAG_BINARY = Tag.BINARY.toString();
 
     /*
@@ -673,7 +684,7 @@ public class YAMLGenerator extends GeneratorBase
             // If one of reserved values ("true", "null"), or, number, preserve quoting:
             } else if (_quotingChecker.needToQuoteValue(text)
                 || (Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS.enabledIn(_formatFeatures)
-                        && PLAIN_NUMBER_P.matcher(text).matches())
+                        && _looksLikeYAMLNumber(text))
                 ) {
                 style = STYLE_QUOTED;
             } else {
@@ -694,6 +705,28 @@ public class YAMLGenerator extends GeneratorBase
     public void writeString(char[] text, int offset, int len) throws IOException
     {
         writeString(new String(text, offset, len));
+    }
+
+    /**
+     * Checks whether given String value would be re-read as a YAML number if emitted
+     * unquoted; used by {@link Feature#ALWAYS_QUOTE_NUMBERS_AS_STRINGS}. Combines the
+     * historical {@link #PLAIN_NUMBER_P} check (retained for backwards compatibility)
+     * with SnakeYAML's own {@code int}/{@code float} resolver patterns, so that YAML 1.1
+     * exponent, hex and underscore number forms -- which {@link #PLAIN_NUMBER_P} does not
+     * match -- are quoted too and thus round-trip. See [dataformats-text#701].
+     *
+     * @since 2.23
+     */
+    protected boolean _looksLikeYAMLNumber(String text) {
+        if (PLAIN_NUMBER_P.matcher(text).matches()) {
+            return true;
+        }
+        for (Pattern p : NUMBER_RESOLVER_PS) {
+            if (p.matcher(text).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java
@@ -707,6 +707,10 @@ public class YAMLGenerator extends GeneratorBase
      * ({@code 1e5}), hex ({@code 0x1F}) and underscore ({@code 12_34}) forms, which
      * {@link #PLAIN_NUMBER_P} does not match, are quoted too and thus round-trip.
      * See [dataformats-text#701].
+     *<p>
+     * 60-base ("sexagesimal") forms like {@code 1:30} are excluded, to match
+     * {@link com.fasterxml.jackson.dataformat.yaml.YAMLParser}, which does not decode
+     * them either.
      *
      * @since 2.21.6
      */
@@ -723,6 +727,15 @@ public class YAMLGenerator extends GeneratorBase
         case '5': case '6': case '7': case '8': case '9':
             break;
         default:
+            return false;
+        }
+        // 23-Jul-2026, tatu: `Resolver.INT`/`Resolver.FLOAT` also match 60-base
+        //    ("sexagesimal") forms like "1:30" or "12:00:01". But `YAMLParser` on
+        //    purpose does NOT decode those (see `_decodeNumberScalar()`), since they
+        //    are much more likely to be Times or IP numbers -- so quoting them here
+        //    would only add noise. Colon cannot occur in any other alternative of
+        //    either pattern, so this excludes exactly the 60-base ones.
+        if (text.indexOf(':') >= 0) {
             return false;
         }
         return PLAIN_NUMBER_P.matcher(text).matches()

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
@@ -245,6 +245,17 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
         // genuine multi-dot version String stays unquoted (not a YAML number)
         String yaml = mapper.writeValueAsString(Collections.singletonMap("key", "2.0.1.2.3")).trim();
         assertEquals("---\nkey: 2.0.1.2.3", yaml);
+
+        // ... and so do 60-base ("sexagesimal") forms: SnakeYAML's resolver patterns
+        // match these, but `YAMLParser` does not decode them (Times, IP numbers), so
+        // quoting them would only add noise
+        for (String value : new String[] { "1:30", "12:00:01", "3:1" }) {
+            yaml = mapper.writeValueAsString(Collections.singletonMap("key", value)).trim();
+            assertEquals("---\nkey: " + value, yaml,
+                    "String '" + value + "' should NOT be quoted");
+            assertEquals(value, mapper.readTree(yaml).get("key").asText(),
+                    "String '" + value + "' should round-trip");
+        }
     }
 
     @Test

--- a/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/dataformat/yaml/ser/GeneratorWithMinimizeTest.java
@@ -221,6 +221,32 @@ public class GeneratorWithMinimizeTest extends ModuleTestBase
                 "key: \"+125\"", yaml);
     }
 
+    // [dataformats-text#701]: PLAIN_NUMBER_P missed YAML 1.1 exponent/hex/underscore
+    // number forms, so ALWAYS_QUOTE_NUMBERS_AS_STRINGS left them unquoted and they were
+    // re-read as numbers (silent corruption). Verify they are now quoted and round-trip.
+    @Test
+    public void testQuoteYAML11NumberFormsStoredAsString701() throws Exception
+    {
+        YAMLFactory f = new YAMLFactory();
+        f.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+        f.configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, true);
+        YAMLMapper mapper = new YAMLMapper(f);
+
+        // forms NOT matched by the old PLAIN_NUMBER_P regex:
+        for (String value : new String[] { "1e5", "0x1F", "12_34", "1.5e-3", "0b101" }) {
+            String yaml = mapper.writeValueAsString(Collections.singletonMap("key", value)).trim();
+            assertEquals("---\nkey: \"" + value + "\"", yaml,
+                    "String '" + value + "' should be quoted");
+            // ... and survive a read+write cycle through the untyped tree
+            assertEquals(value, mapper.readTree(yaml).get("key").asText(),
+                    "String '" + value + "' should round-trip");
+        }
+
+        // genuine multi-dot version String stays unquoted (not a YAML number)
+        String yaml = mapper.writeValueAsString(Collections.singletonMap("key", "2.0.1.2.3")).trim();
+        assertEquals("---\nkey: 2.0.1.2.3", yaml);
+    }
+
     @Test
     public void testNonQuoteNumberStoredAsString() throws Exception
     {


### PR DESCRIPTION
Fixes #701

## Root cause
With `MINIMIZE_QUOTES` + `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` enabled, `YAMLGenerator.writeString` decides whether a String must be quoted by matching it against `PLAIN_NUMBER_P` (`[+-]?[0-9]*(\.[0-9]*)?`). That regex only recognizes plain decimal integers/floats, so YAML 1.1 number forms it does **not** match — exponent (`1e5`), hex (`0x1F`), underscore (`12_34`) — were emitted **unquoted**. SnakeYAML (and every other YAML reader) then resolves those plain scalars back to numbers, so the value silently changes on a read/write cycle (`"1e5"` -> `100000.0`). The feature is documented to keep number-like Strings distinguishable, but its detection was incomplete.

## Change
Detection now also matches SnakeYAML's own implicit `int`/`float` resolver patterns (`Resolver.INT` / `Resolver.FLOAT`) — the exact patterns the parser uses to resolve plain scalars — in addition to the historical `PLAIN_NUMBER_P` (kept, so existing output is a strict superset and no previously-quoted value becomes unquoted). Any String that would resolve to a number is therefore quoted and round-trips. Scoped to the opt-in `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` path; default `MINIMIZE_QUOTES` output is unchanged.

## Test evidence
Added `GeneratorWithMinimizeTest.testQuoteYAML11NumberFormsStoredAsString701`: asserts `1e5`, `0x1F`, `12_34`, `1.5e-3`, `0b101` are now quoted and round-trip through `readTree`, while a genuine non-number version String (`2.0.1.2.3`) stays unquoted. The test **fails before** this change (`1e5` emitted as `key: 1e5`) and **passes after**.

Verification done: full `yaml` module suite green (`./mvnw -pl yaml test` — 168 tests, 0 failures), including the pre-existing `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` tests; the new test confirmed red-before/green-after.