### PR TITLE
Pass normalized separator in CsvSchema.withArrayElementSeparator (avoid null state / NPE)

### DIFF
--- a/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
+++ b/csv/src/main/java/com/fasterxml/jackson/dataformat/csv/CsvSchema.java
@@ -1206,7 +1206,7 @@ public class CsvSchema
     public CsvSchema withArrayElementSeparator(String separator) {
         String sep = separator == null ? "" : separator;
         return (_arrayElementSeparator.equals(sep)) ? this : new CsvSchema(_columns, _features,
-            _columnSeparator, _quoteChar, _escapeChar, _lineSeparator, separator,
+            _columnSeparator, _quoteChar, _escapeChar, _lineSeparator, sep,
             _nullValue, _columnsByName, _anyPropertyName);
     }
 

--- a/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
+++ b/csv/src/test/java/com/fasterxml/jackson/dataformat/csv/schema/CsvSchemaTest.java
@@ -253,4 +253,21 @@ public class CsvSchemaTest extends ModuleTestBase
 
         _verifyLinks(pointSchema);
     }
+
+    // [dataformats-text#710]: withArrayElementSeparator(null) should normalize
+    // to "no separator" (like the local `sep` used for the equality check), not
+    // store a null that later NPEs in hasArrayElementSeparator()
+    @Test
+    public void testWithArrayElementSeparatorNull()
+    {
+        CsvSchema schema = CsvSchema.emptySchema().withArrayElementSeparator(";");
+        assertTrue(schema.hasArrayElementSeparator());
+
+        CsvSchema cleared = schema.withArrayElementSeparator(null);
+        assertFalse(cleared.hasArrayElementSeparator());
+        assertEquals("", cleared.getArrayElementSeparator());
+
+        // and calling it again must not throw
+        assertFalse(cleared.withArrayElementSeparator(null).hasArrayElementSeparator());
+    }
 }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -331,3 +331,9 @@ Michał Majchrowicz (@sectroyer)
 * Reported #707: (yaml) `StackOverflowError` when reading deeply nested merge keys
   (`<<`) with `YAMLAnchorReplayingFactory` (GHSA-255r-36wv-4qpr)
  (2.21.6)
+
+Uttam Limbani (@uttam12331)
+
+* Fixed #710: (csv) `CsvSchema.withArrayElementSeparator(null)` stores `null`,
+  causing `NullPointerException` from `hasArrayElementSeparator()`
+ (2.21.6)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,6 +16,9 @@ Active Maintainers:
 
 2.21.6 (not yet released)
 
+#710: (csv) `CsvSchema.withArrayElementSeparator(null)` stores `null`, causing
+  `NullPointerException` from `hasArrayElementSeparator()`
+ (fix by @uttam12331)
 #701: (yaml) `ALWAYS_QUOTE_NUMBERS_AS_STRINGS` does not quote YAML 1.1 exponent
   (`1e5`), hex (`0x1F`) and underscore (`12_34`) number forms
  (reported by @EverNife)


### PR DESCRIPTION
## Summary

`CsvSchema.withArrayElementSeparator(String separator)` normalizes a `null` argument to `""` in the local `sep` and uses `sep` for the equality check, but then passes the **raw** `separator` to the copy constructor:

```java
public CsvSchema withArrayElementSeparator(String separator) {
    String sep = separator == null ? "" : separator;
    return (_arrayElementSeparator.equals(sep)) ? this : new CsvSchema(_columns, _features,
        _columnSeparator, _quoteChar, _escapeChar, _lineSeparator, separator, // <-- should be `sep`
        _nullValue, _columnsByName, _anyPropertyName);
}
```

The copy constructor stores the value directly, so `withArrayElementSeparator(null)` leaves `_arrayElementSeparator == null`.

## Impact

This breaks the field's non-null invariant:

- `hasArrayElementSeparator()` does `return !_arrayElementSeparator.isEmpty();` → `NullPointerException`.
- A subsequent `withArrayElementSeparator(...)` call NPEs on `_arrayElementSeparator.equals(sep)`.

Every sibling builder stores exactly the value it compared against (e.g. `withColumnSeparator` compares `_columnSeparator == sep` and constructs with `sep`); `withArrayElementSeparator` is the only one that compares `sep` but constructs with `separator`.

## Fix

Pass the already-normalized `sep`:

```diff
-            _columnSeparator, _quoteChar, _escapeChar, _lineSeparator, separator,
+            _columnSeparator, _quoteChar, _escapeChar, _lineSeparator, sep,
```

## Tests

Added `CsvSchemaTest.testWithArrayElementSeparatorNull`, which sets a separator, clears it with `withArrayElementSeparator(null)`, and asserts `hasArrayElementSeparator()` returns `false` (and does not throw) — this fails with an NPE on the current code and passes with the fix.

Happy to add a `release-notes/CREDITS` entry or sign the CLA if needed.
