### PR TITLE
use System.arraycopy to avoid copy byte one at a time

### DIFF
--- a/csv/src/main/java/tools/jackson/dataformat/csv/impl/UTF8Reader.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/impl/UTF8Reader.java
@@ -420,9 +420,7 @@ public final class UTF8Reader
             if (_inputPtr > 0) {
                 // Can only do so if buffer mutable
                 if (!_inputBufferReadOnly) {
-                    for (int i = 0; i < available; ++i) {
-                        _inputBuffer[i] = _inputBuffer[_inputPtr+i];
-                    }
+                    System.arraycopy(_inputBuffer, _inputPtr, _inputBuffer, 0, available);
                     _inputPtr = 0;
                     _inputEnd = available;
                 }

--- a/toml/src/main/java/tools/jackson/dataformat/toml/UTF8Reader.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/UTF8Reader.java
@@ -350,9 +350,7 @@ public final class UTF8Reader
             if (_inputPtr > 0) {
                 // Can only do so if buffer mutable
                 if (!_inputBufferReadOnly) {
-                    for (int i = 0; i < available; ++i) {
-                        _inputBuffer[i] = _inputBuffer[_inputPtr+i];
-                    }
+                    System.arraycopy(_inputBuffer, _inputPtr, _inputBuffer, 0, available);
                     _inputPtr = 0;
                     _inputEnd = available;
                 }

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/UTF8Reader.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/UTF8Reader.java
@@ -457,9 +457,7 @@ public final class UTF8Reader
             if (_inputPtr > 0) {
                 // Can only do so if buffer mutable
                 if (!_inputBufferReadOnly) {
-                    for (int i = 0; i < available; ++i) {
-                        _inputBuffer[i] = _inputBuffer[_inputPtr+i];
-                    }
+                    System.arraycopy(_inputBuffer, _inputPtr, _inputBuffer, 0, available);
                     _inputPtr = 0;
                     _inputEnd = available;
                 }


### PR DESCRIPTION
related to https://github.com/FasterXML/jackson-core/pull/1660/