### PR TITLE
Fix #589: support non-scalar YAML mapping keys

### DIFF
--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -356,6 +356,15 @@ public class YAMLParser extends ParserBase
                             _streamReadContext = _streamReadContext.getParent();
                             return _updateToken(JsonToken.END_OBJECT);
                         }
+                        // [dataformats-text#589]: complex (non-scalar) mapping keys
+                        if (evt.getEventId() == Event.ID.SequenceStart
+                                || evt.getEventId() == Event.ID.MappingStart) {
+                            final String name = _decodeComplexPropertyName(evt);
+                            _streamReadConstraints.validateNameLength(name.length());
+                            _currentName = name;
+                            _streamReadContext.setCurrentName(name);
+                            return _updateToken(JsonToken.PROPERTY_NAME);
+                        }
                         _reportError("Expected a property name (Scalar value in YAML), got this instead: "+evt);
                     }
 
@@ -479,6 +488,119 @@ public class YAMLParser extends ParserBase
 
     protected Event nextEvent() {
         return _yamlParser.next();
+    }
+
+    /**
+     * Helper method called when a non-scalar event (Sequence or Mapping start) is encountered
+     * where a property name is expected -- indicates a "complex key" in YAML terms.
+     * Consumes the full key structure and converts to a canonical String representation
+     * (flow-style) so that Jackson's scalar-only property name model can represent it.
+     *
+     * @since 3.2
+     */
+    protected String _decodeComplexPropertyName(Event evt) throws JacksonException
+    {
+        StringBuilder sb = new StringBuilder(32);
+        _appendComplexKey(evt, sb, 0);
+        return sb.toString();
+    }
+
+    private void _appendComplexKey(Event evt, StringBuilder sb, int depth) throws JacksonException
+    {
+        _streamReadConstraints.validateNestingDepth(depth);
+        switch (evt.getEventId()) {
+        case Scalar:
+            _appendComplexKeyScalar(((ScalarEvent) evt).getValue(), sb);
+            return;
+        case SequenceStart:
+            sb.append('[');
+            _appendComplexKeySequenceContent(sb, depth + 1);
+            sb.append(']');
+            return;
+        case MappingStart:
+            sb.append('{');
+            _appendComplexKeyMappingContent(sb, depth + 1);
+            sb.append('}');
+            return;
+        default:
+            _reportError("Unexpected YAML event for complex property name, expected Scalar, Sequence or Mapping start, got: "+evt);
+        }
+    }
+
+    private void _appendComplexKeySequenceContent(StringBuilder sb, int depth) throws JacksonException
+    {
+        boolean first = true;
+        while (true) {
+            Event evt = nextEvent();
+            if (evt == null) {
+                _reportError("Unexpected end-of-input in complex property name (sequence)");
+            }
+            if (evt.getEventId() == Event.ID.SequenceEnd) {
+                return;
+            }
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+            _appendComplexKey(evt, sb, depth);
+        }
+    }
+
+    private void _appendComplexKeyMappingContent(StringBuilder sb, int depth) throws JacksonException
+    {
+        boolean first = true;
+        while (true) {
+            Event keyEvt = nextEvent();
+            if (keyEvt == null) {
+                _reportError("Unexpected end-of-input in complex property name (mapping)");
+            }
+            if (keyEvt.getEventId() == Event.ID.MappingEnd) {
+                return;
+            }
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+            _appendComplexKey(keyEvt, sb, depth);
+            sb.append(": ");
+            Event valEvt = nextEvent();
+            if (valEvt == null) {
+                _reportError("Unexpected end-of-input in complex property name (mapping value)");
+            }
+            _appendComplexKey(valEvt, sb, depth);
+        }
+    }
+
+    private void _appendComplexKeyScalar(String value, StringBuilder sb)
+    {
+        if (_needsQuotesForComplexKey(value)) {
+            sb.append('"');
+            for (int i = 0, len = value.length(); i < len; ++i) {
+                char c = value.charAt(i);
+                if (c == '"' || c == '\\') {
+                    sb.append('\\');
+                }
+                sb.append(c);
+            }
+            sb.append('"');
+        } else {
+            sb.append(value);
+        }
+    }
+
+    private boolean _needsQuotesForComplexKey(String value)
+    {
+        if (value.isEmpty()) {
+            return true;
+        }
+        for (int i = 0, len = value.length(); i < len; ++i) {
+            char c = value.charAt(i);
+            if (c == ':' || c == ',' || c == '[' || c == ']' || c == '{' || c == '}'
+                    || c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected JsonToken _decodeScalar(ScalarEvent scalar) throws JacksonException

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -346,10 +346,10 @@ public class YAMLParser extends ParserBase
             if (_streamReadContext.inObject()) {
                 if (_currToken != JsonToken.PROPERTY_NAME) {
                     if (evt.getEventId() != Event.ID.Scalar) {
-                        _currentAnchor = Optional.empty();
                         _lastTagEvent = null;
                         // end is fine
                         if (evt.getEventId() == Event.ID.MappingEnd) {
+                            _currentAnchor = Optional.empty();
                             if (!_streamReadContext.inObject()) { // sanity check is optional, but let's do it for now
                                 _reportMismatchedEndMarker('}', ']');
                             }
@@ -358,13 +358,30 @@ public class YAMLParser extends ParserBase
                         }
                         // [dataformats-text#589]: complex (non-scalar) mapping keys
                         if (evt.getEventId() == Event.ID.SequenceStart
-                                || evt.getEventId() == Event.ID.MappingStart) {
+                                || evt.getEventId() == Event.ID.MappingStart
+                                || evt.getEventId() == Event.ID.Alias) {
+                            final boolean firstEntry = (_currToken == JsonToken.START_OBJECT);
+                            if (evt.getEventId() == Event.ID.Alias) {
+                                if (!firstEntry) {
+                                    _currentAnchor = Optional.empty();
+                                    _lastTagEvent = evt;
+                                }
+                            } else {
+                                final Optional<Anchor> newAnchor = ((NodeEvent) evt).getAnchor();
+                                if (newAnchor.isPresent() || !firstEntry) {
+                                    _currentAnchor = newAnchor;
+                                }
+                                if (!firstEntry) {
+                                    _lastTagEvent = evt;
+                                }
+                            }
                             final String name = _decodeComplexPropertyName(evt);
                             _streamReadConstraints.validateNameLength(name.length());
                             _currentName = name;
                             _streamReadContext.setCurrentName(name);
                             return _updateToken(JsonToken.PROPERTY_NAME);
                         }
+                        _currentAnchor = Optional.empty();
                         _reportError("Expected a property name (Scalar value in YAML), got this instead: "+evt);
                     }
 
@@ -496,7 +513,7 @@ public class YAMLParser extends ParserBase
      * Consumes the full key structure and converts to a canonical String representation
      * (flow-style) so that Jackson's scalar-only property name model can represent it.
      *
-     * @since 3.2
+     * @since 3.3
      */
     protected String _decodeComplexPropertyName(Event evt) throws JacksonException
     {
@@ -505,22 +522,45 @@ public class YAMLParser extends ParserBase
         return sb.toString();
     }
 
+    private Event _nextComplexKeyEvent()
+    {
+        while (true) {
+            Event evt = nextEvent();
+            if (evt == null) {
+                return null;
+            }
+            if (evt.getEventId() == Event.ID.Comment) {
+                continue;
+            }
+            return evt;
+        }
+    }
+
     private void _appendComplexKey(Event evt, StringBuilder sb, int depth) throws JacksonException
     {
-        _streamReadConstraints.validateNestingDepth(depth);
+        final int nestingDepth = _streamReadContext.getNestingDepth() + depth;
         switch (evt.getEventId()) {
         case Scalar:
+            _streamReadConstraints.validateNestingDepth(nestingDepth);
             _appendComplexKeyScalar(((ScalarEvent) evt).getValue(), sb);
             return;
         case SequenceStart:
+            _streamReadConstraints.validateNestingDepth(nestingDepth);
             sb.append('[');
             _appendComplexKeySequenceContent(sb, depth + 1);
             sb.append(']');
             return;
         case MappingStart:
+            _streamReadConstraints.validateNestingDepth(nestingDepth);
             sb.append('{');
             _appendComplexKeyMappingContent(sb, depth + 1);
             sb.append('}');
+            return;
+        case Alias:
+            _streamReadConstraints.validateNestingDepth(nestingDepth);
+            AliasEvent alias = (AliasEvent) evt;
+            sb.append('*');
+            sb.append(alias.getAnchor().orElseThrow(() -> new RuntimeException("Alias must be provided.")).getValue());
             return;
         default:
             _reportError("Unexpected YAML event for complex property name, expected Scalar, Sequence or Mapping start, got: "+evt);
@@ -531,7 +571,7 @@ public class YAMLParser extends ParserBase
     {
         boolean first = true;
         while (true) {
-            Event evt = nextEvent();
+            Event evt = _nextComplexKeyEvent();
             if (evt == null) {
                 _reportError("Unexpected end-of-input in complex property name (sequence)");
             }
@@ -550,7 +590,7 @@ public class YAMLParser extends ParserBase
     {
         boolean first = true;
         while (true) {
-            Event keyEvt = nextEvent();
+            Event keyEvt = _nextComplexKeyEvent();
             if (keyEvt == null) {
                 _reportError("Unexpected end-of-input in complex property name (mapping)");
             }
@@ -563,7 +603,7 @@ public class YAMLParser extends ParserBase
             first = false;
             _appendComplexKey(keyEvt, sb, depth);
             sb.append(": ");
-            Event valEvt = nextEvent();
+            Event valEvt = _nextComplexKeyEvent();
             if (valEvt == null) {
                 _reportError("Unexpected end-of-input in complex property name (mapping value)");
             }

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
@@ -10,6 +10,7 @@ import org.snakeyaml.engine.v2.api.LoadSettings;
 
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.dataformat.yaml.JacksonYAMLParseException;
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
@@ -660,6 +661,51 @@ public class StreamingYAMLParseTest extends ModuleTestBase
             fail("expected to fail by now");
         } catch (JacksonYAMLParseException e) {
             assertTrue(e.getMessage().startsWith("The incoming YAML document exceeds the limit: 5 code points."));
+        }
+    }
+
+    // [dataformats-text#589]: sequence (and mapping) as mapping key
+    @Test
+    public void testComplexMappingKeySequence() throws Exception
+    {
+        final String YAML = "? [user, 123]\n: name: Ivan\n  age: 30\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("[user, 123]", p.currentName());
+            assertEquals("[user, 123]", p.getString());
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("name", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("Ivan", p.getString());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("age", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(30, p.getIntValue());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+
+        JsonNode node = MAPPER.readTree(YAML);
+        assertTrue(node.has("[user, 123]"));
+        assertEquals("Ivan", node.get("[user, 123]").get("name").asString());
+        assertEquals(30, node.get("[user, 123]").get("age").asInt());
+    }
+
+    @Test
+    public void testComplexMappingKeyMapping() throws Exception
+    {
+        final String YAML = "? {foo: bar}\n: 42\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("{foo: bar}", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(42, p.getIntValue());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
         }
     }
 

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/deser/StreamingYAMLParseTest.java
@@ -707,6 +707,117 @@ public class StreamingYAMLParseTest extends ModuleTestBase
             assertToken(JsonToken.END_OBJECT, p.nextToken());
             assertNull(p.nextToken());
         }
+
+        JsonNode node = MAPPER.readTree(YAML);
+        assertTrue(node.has("{foo: bar}"));
+        assertEquals(42, node.get("{foo: bar}").asInt());
+    }
+
+    @Test
+    public void testComplexMappingKeyImplicitFlow() throws Exception
+    {
+        final String YAML = "[user, 123]: 42\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("[user, 123]", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(42, p.getIntValue());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    @Test
+    public void testComplexMappingKeyNested() throws Exception
+    {
+        final String YAML = "? {outer: {inner: x}}\n: 42\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("{outer: {inner: x}}", p.currentName());
+            assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(42, p.getIntValue());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    @Test
+    public void testComplexMappingKeyEmptyCollections() throws Exception
+    {
+        final String YAML = "? []\n: empty-seq\n? {}\n: empty-map\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("[]", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("empty-seq", p.getString());
+
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("{}", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("empty-map", p.getString());
+
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    @Test
+    public void testComplexMappingKeyQuotedSpecials() throws Exception
+    {
+        final String YAML = "? [\"a:b\", \"c,d\", has space]\n: ok\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("[\"a:b\", \"c,d\", \"has space\"]", p.currentName());
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("ok", p.getString());
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    @Test
+    public void testComplexMappingKeyAliasInKey() throws Exception
+    {
+        final String YAML = "? &key1 [user, 123]\n: first\n? *key1\n: second\n";
+        try (JsonParser p = MAPPER.createParser(YAML)) {
+            assertToken(JsonToken.START_OBJECT, p.nextToken());
+
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("[user, 123]", p.currentName());
+
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("first", p.getString());
+
+            assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("*key1", p.currentName());
+
+            assertToken(JsonToken.VALUE_STRING, p.nextToken());
+            assertEquals("second", p.getString());
+
+            assertToken(JsonToken.END_OBJECT, p.nextToken());
+            assertNull(p.nextToken());
+        }
+    }
+
+    @Test
+    public void testComplexMappingKeyObjectAnchorDeferredOnFirstEntry() throws Exception
+    {
+        final String YAML = "&obj1\n? [user, 123]\n: 42\n";
+        YAMLParser yp = (YAMLParser) MAPPER.createParser(YAML);
+        assertToken(JsonToken.START_OBJECT, yp.nextToken());
+        assertEquals("obj1", yp.getObjectId());
+        assertToken(JsonToken.PROPERTY_NAME, yp.nextToken());
+        assertEquals("[user, 123]", yp.currentName());
+        assertToken(JsonToken.VALUE_NUMBER_INT, yp.nextToken());
+        assertEquals(42, yp.getIntValue());
+        assertToken(JsonToken.END_OBJECT, yp.nextToken());
+        assertNull(yp.nextToken());
+        yp.close();
     }
 
     // In Jackson 3.x, non-Number token should NOT throw exception for parser.getNumberType()


### PR DESCRIPTION
Fixes #589

## Summary

- Handle YAML explicit complex mapping keys (`? [...]` / `? {...}`) in `YAMLParser` when SnakeYAML emits `SequenceStart` or `MappingStart` where a property name is expected
- Consume the full key structure and expose it as a flow-style string property name (e.g. `[user, 123]`, `{foo: bar}`) so `YAMLMapper` / `readTree()` can parse documents that use sequence or mapping keys per the YAML spec
- Support Alias references and skip Comment events while decoding complex keys; validate nesting depth against current parser context; preserve deferred object anchor on first complex key entry
- Add streaming parser and `readTree` tests for sequence/mapping complex keys, implicit flow keys, nested/empty keys, quoted specials, and alias-in-key

## Test plan

- [x] `mvn -pl yaml -Dtest=StreamingYAMLParseTest#testComplexMappingKey*` (9 tests, 0 failures; Java 17)
- [x] `StreamingYAMLParseTest#testComplexMappingKeySequence` — reproduces issue example `? [user, 123]: ...`
- [x] `StreamingYAMLParseTest#testComplexMappingKeyMapping` — mapping-as-key case with `readTree`
- [x] Additional cases: implicit flow key, nested complex key, empty `[]`/`{}`, quoted specials, alias-in-key, object anchor deferral on first entry