### PR TITLE
Use `NumberOutput` for number writes in Properties, TOML and YAML generators

### DIFF
--- a/properties/src/main/java/tools/jackson/dataformat/javaprop/JavaPropsGenerator.java
+++ b/properties/src/main/java/tools/jackson/dataformat/javaprop/JavaPropsGenerator.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import tools.jackson.core.*;
 import tools.jackson.core.base.GeneratorBase;
 import tools.jackson.core.io.IOContext;
+import tools.jackson.core.io.NumberOutput;
 import tools.jackson.core.util.JacksonFeatureSet;
 
 import tools.jackson.dataformat.javaprop.io.JPropWriteContext;
@@ -388,7 +389,7 @@ public abstract class JavaPropsGenerator
     public JsonGenerator writeNumber(int i) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeUnescapedEntry(String.valueOf(i));
+        _writeUnescapedEntry(i);
         return this;
     }
 
@@ -396,7 +397,7 @@ public abstract class JavaPropsGenerator
     public JsonGenerator writeNumber(long l) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeUnescapedEntry(String.valueOf(l));
+        _writeUnescapedEntry(l);
         return this;
     }
 
@@ -407,7 +408,7 @@ public abstract class JavaPropsGenerator
             return writeNull();
         }
         _verifyValueWrite("write number");
-        _writeUnescapedEntry(String.valueOf(v));
+        _writeUnescapedEntry(v.toString());
         return this;
     }
     
@@ -415,7 +416,7 @@ public abstract class JavaPropsGenerator
     public JsonGenerator writeNumber(double d) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeUnescapedEntry(String.valueOf(d));
+        _writeUnescapedEntry(d);
         return this;
     }    
 
@@ -423,7 +424,7 @@ public abstract class JavaPropsGenerator
     public JsonGenerator writeNumber(float f) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeUnescapedEntry(String.valueOf(f));
+        _writeUnescapedEntry(f);
         return this;
     }
 
@@ -510,6 +511,40 @@ public abstract class JavaPropsGenerator
     protected abstract void _writeEscapedEntry(char[] text, int offset, int len) throws JacksonException;
 
     protected abstract void _writeUnescapedEntry(String value) throws JacksonException;
+
+    /**
+     * Default implementations for numeric entries go through {@code String}
+     * representation; sub-classes with direct access to an output buffer
+     * may override to write digits without intermediate {@code String}.
+     *
+     * @since 3.3
+     */
+    protected void _writeUnescapedEntry(int value) throws JacksonException {
+        _writeUnescapedEntry(Integer.toString(value));
+    }
+
+    /**
+     * @since 3.3
+     */
+    protected void _writeUnescapedEntry(long value) throws JacksonException {
+        _writeUnescapedEntry(Long.toString(value));
+    }
+
+    /**
+     * @since 3.3
+     */
+    protected void _writeUnescapedEntry(double value) throws JacksonException {
+        _writeUnescapedEntry(NumberOutput.toString(value,
+                isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)));
+    }
+
+    /**
+     * @since 3.3
+     */
+    protected void _writeUnescapedEntry(float value) throws JacksonException {
+        _writeUnescapedEntry(NumberOutput.toString(value,
+                isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)));
+    }
 
     protected abstract void _writeRaw(char c) throws JacksonException;
     protected abstract void _writeRaw(String text) throws JacksonException;

--- a/properties/src/main/java/tools/jackson/dataformat/javaprop/impl/WriterBackedGenerator.java
+++ b/properties/src/main/java/tools/jackson/dataformat/javaprop/impl/WriterBackedGenerator.java
@@ -5,6 +5,7 @@ import java.io.Writer;
 
 import tools.jackson.core.*;
 import tools.jackson.core.io.IOContext;
+import tools.jackson.core.io.NumberOutput;
 import tools.jackson.dataformat.javaprop.JavaPropsGenerator;
 import tools.jackson.dataformat.javaprop.JavaPropsSchema;
 import tools.jackson.dataformat.javaprop.io.JPropEscapes;
@@ -195,6 +196,64 @@ public class WriterBackedGenerator extends JavaPropsGenerator
         _writeRaw(_schema.keyValueSeparator());
 
         _writeRaw(value);
+        _writeLinefeed();
+    }
+
+    @Override
+    protected void _writeUnescapedEntry(int value) throws JacksonException
+    {
+        _writeRaw(_basePath);
+        _writeRaw(_schema.keyValueSeparator());
+        // up to 10 digits and possible minus sign
+        if ((_outputTail + 11) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputInt(value, _outputBuffer, _outputTail);
+        _writeLinefeed();
+    }
+
+    @Override
+    protected void _writeUnescapedEntry(long value) throws JacksonException
+    {
+        _writeRaw(_basePath);
+        _writeRaw(_schema.keyValueSeparator());
+        // up to 19 digits and possible minus sign
+        if ((_outputTail + 20) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputLong(value, _outputBuffer, _outputTail);
+        _writeLinefeed();
+    }
+
+    @Override
+    protected void _writeUnescapedEntry(double value) throws JacksonException
+    {
+        if (!isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)) {
+            _writeUnescapedEntry(NumberOutput.toString(value, false));
+            return;
+        }
+        _writeRaw(_basePath);
+        _writeRaw(_schema.keyValueSeparator());
+        if ((_outputTail + NumberOutput.MAX_DOUBLE_BYTES) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputDouble(value, _outputBuffer, _outputTail);
+        _writeLinefeed();
+    }
+
+    @Override
+    protected void _writeUnescapedEntry(float value) throws JacksonException
+    {
+        if (!isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)) {
+            _writeUnescapedEntry(NumberOutput.toString(value, false));
+            return;
+        }
+        _writeRaw(_basePath);
+        _writeRaw(_schema.keyValueSeparator());
+        if ((_outputTail + NumberOutput.MAX_FLOAT_BYTES) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputFloat(value, _outputBuffer, _outputTail);
         _writeLinefeed();
     }
 

--- a/properties/src/test/java/module-info.java
+++ b/properties/src/test/java/module-info.java
@@ -18,6 +18,7 @@ module tools.jackson.dataformat.properties
     opens tools.jackson.dataformat.javaprop.deser;
     opens tools.jackson.dataformat.javaprop.deser.convert;
     opens tools.jackson.dataformat.javaprop.filter;
+    opens tools.jackson.dataformat.javaprop.ser;
     opens tools.jackson.dataformat.javaprop.ser.dos;
     opens tools.jackson.dataformat.javaprop.testutil;
     opens tools.jackson.dataformat.javaprop.testutil.failure;

--- a/properties/src/test/java/tools/jackson/dataformat/javaprop/ser/NumberGenerationTest.java
+++ b/properties/src/test/java/tools/jackson/dataformat/javaprop/ser/NumberGenerationTest.java
@@ -1,0 +1,209 @@
+package tools.jackson.dataformat.javaprop.ser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.io.NumberOutput;
+
+import tools.jackson.dataformat.javaprop.JavaPropsFactory;
+import tools.jackson.dataformat.javaprop.JavaPropsMapper;
+import tools.jackson.dataformat.javaprop.ModuleTestBase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for numeric output of {@code JavaPropsGenerator}: with
+ * {@code Writer}-backed output, {@code int}/{@code long} are written via
+ * {@code NumberOutput.outputInt/outputLong()} straight into output buffer,
+ * and {@code double}/{@code float} likewise when
+ * {@code StreamWriteFeature.USE_FAST_DOUBLE_WRITER} is enabled.
+ * {@code Properties}-backed output goes through {@code String}s but must
+ * produce the same text.
+ */
+public class NumberGenerationTest extends ModuleTestBase
+{
+    @JsonPropertyOrder({ "i", "l", "d", "f", "s" })
+    static class Numbers {
+        public int i;
+        public long l;
+        public double d;
+        public float f;
+        public short s;
+
+        public Numbers(int i, long l, double d, float f, short s) {
+            this.i = i; this.l = l; this.d = d; this.f = f; this.s = s;
+        }
+    }
+
+    private final JavaPropsMapper DEFAULT_MAPPER = newPropertiesMapper();
+
+    private final JavaPropsMapper FAST_MAPPER = propertiesMapperBuilder()
+            .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+            .build();
+
+    private final static double[] DOUBLES = new double[] {
+        0.0, -0.0, 1.0, -1.0, 1.25, -2.5, 0.1, 0.3, 1e-7, 1.0e20, 1.0e21,
+        123456789.125, Double.MIN_VALUE, Double.MAX_VALUE, Math.PI, -Math.E,
+        Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+    };
+
+    private final static float[] FLOATS = new float[] {
+        0.0f, -0.0f, 1.0f, -1.0f, 1.25f, -2.5f, 0.1f, 1.89f, 1e-7f, 1.0e20f,
+        Float.MIN_VALUE, Float.MAX_VALUE, (float) Math.PI,
+        Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY,
+    };
+
+    @Test
+    public void testIntegersPojo() throws Exception
+    {
+        Numbers n = new Numbers(Integer.MIN_VALUE, Long.MAX_VALUE, 1.5, -2.5f, (short) -7);
+        String exp = "i=-2147483648\nl=9223372036854775807\nd=1.5\nf=-2.5\ns=-7\n";
+        assertEquals(exp, DEFAULT_MAPPER.writeValueAsString(n));
+        assertEquals(exp, FAST_MAPPER.writeValueAsString(n));
+
+        Properties props = DEFAULT_MAPPER.writeValueAsProperties(n);
+        assertEquals("-2147483648", props.getProperty("i"));
+        assertEquals("9223372036854775807", props.getProperty("l"));
+        assertEquals("1.5", props.getProperty("d"));
+        assertEquals("-2.5", props.getProperty("f"));
+        assertEquals("-7", props.getProperty("s"));
+    }
+
+    @Test
+    public void testDoublesDefaultWriter() throws Exception {
+        for (double d : DOUBLES) {
+            String exp = "v=" + Double.toString(d) + "\n";
+            assertEquals(exp, _write(DEFAULT_MAPPER, g -> g.writeNumber(d), false));
+            assertEquals(exp, _write(DEFAULT_MAPPER, g -> g.writeNumber(d), true));
+            assertEquals(Double.toString(d), _writeProps(DEFAULT_MAPPER, g -> g.writeNumber(d)));
+        }
+    }
+
+    @Test
+    public void testDoublesFastWriter() throws Exception {
+        for (double d : DOUBLES) {
+            String exp = "v=" + NumberOutput.toString(d, true) + "\n";
+            assertEquals(exp, _write(FAST_MAPPER, g -> g.writeNumber(d), false));
+            assertEquals(exp, _write(FAST_MAPPER, g -> g.writeNumber(d), true));
+            assertEquals(NumberOutput.toString(d, true), _writeProps(FAST_MAPPER, g -> g.writeNumber(d)));
+        }
+    }
+
+    @Test
+    public void testFloatsDefaultWriter() throws Exception {
+        for (float f : FLOATS) {
+            String exp = "v=" + Float.toString(f) + "\n";
+            assertEquals(exp, _write(DEFAULT_MAPPER, g -> g.writeNumber(f), false));
+            assertEquals(exp, _write(DEFAULT_MAPPER, g -> g.writeNumber(f), true));
+            assertEquals(Float.toString(f), _writeProps(DEFAULT_MAPPER, g -> g.writeNumber(f)));
+        }
+    }
+
+    @Test
+    public void testFloatsFastWriter() throws Exception {
+        for (float f : FLOATS) {
+            String exp = "v=" + NumberOutput.toString(f, true) + "\n";
+            assertEquals(exp, _write(FAST_MAPPER, g -> g.writeNumber(f), false));
+            assertEquals(exp, _write(FAST_MAPPER, g -> g.writeNumber(f), true));
+            assertEquals(NumberOutput.toString(f, true), _writeProps(FAST_MAPPER, g -> g.writeNumber(f)));
+        }
+    }
+
+    // Write enough entries to cross the output buffer boundary multiple times
+    @Test
+    public void testManyValuesAcrossBufferBoundary() throws Exception
+    {
+        for (JavaPropsMapper mapper : new JavaPropsMapper[] { DEFAULT_MAPPER, FAST_MAPPER }) {
+            final boolean fast = mapper.isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER);
+            final int ROWS = 1500;
+            StringBuilder exp = new StringBuilder();
+            for (int i = 0; i < ROWS; ++i) {
+                exp.append("i").append(i).append('=').append(_int(i)).append('\n');
+                exp.append("l").append(i).append('=').append(_long(i)).append('\n');
+                exp.append("d").append(i).append('=')
+                    .append(NumberOutput.toString(_double(i), fast)).append('\n');
+                exp.append("f").append(i).append('=')
+                    .append(NumberOutput.toString(_float(i), fast)).append('\n');
+            }
+            String expected = exp.toString();
+            assertEquals(expected, _writeRows(mapper, ROWS, false));
+            assertEquals(expected, _writeRows(mapper, ROWS, true));
+        }
+    }
+
+    private static int _int(int i) { return (i * 7919) * ((i & 1) == 0 ? 1 : -1); }
+    private static long _long(int i) { return ((long) i * 1_000_000_007L) * ((i & 2) == 0 ? 1 : -1); }
+    private static double _double(int i) {
+        return (i * 1.000001) / 7.0 * ((i & 1) == 0 ? 1 : -1) + (i % 5) * 1e-9;
+    }
+    private static float _float(int i) {
+        return (i * 1.0001f) / 3.0f * ((i & 2) == 0 ? 1 : -1) + (i % 3) * 1e-5f;
+    }
+
+    private String _writeRows(JavaPropsMapper mapper, int rows, boolean useStream)
+    {
+        StringWriter sw = new StringWriter();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (JsonGenerator g = useStream ? mapper.createGenerator(bytes) : mapper.createGenerator(sw)) {
+            g.writeStartObject();
+            for (int i = 0; i < rows; ++i) {
+                g.writeName("i" + i);
+                g.writeNumber(_int(i));
+                g.writeName("l" + i);
+                g.writeNumber(_long(i));
+                g.writeName("d" + i);
+                g.writeNumber(_double(i));
+                g.writeName("f" + i);
+                g.writeNumber(_float(i));
+            }
+            g.writeEndObject();
+        }
+        return useStream ? new String(bytes.toByteArray(), StandardCharsets.UTF_8) : sw.toString();
+    }
+
+    /*
+    /**********************************************************************
+    /* Helpers
+    /**********************************************************************
+     */
+
+    private interface GenBody { void write(JsonGenerator g); }
+
+    private String _write(JavaPropsMapper mapper, GenBody body, boolean useStream) {
+        StringWriter sw = new StringWriter();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (JsonGenerator g = useStream ? mapper.createGenerator(bytes) : mapper.createGenerator(sw)) {
+            g.writeStartObject();
+            g.writeName("v");
+            body.write(g);
+            g.writeEndObject();
+        }
+        return useStream ? new String(bytes.toByteArray(), StandardCharsets.UTF_8) : sw.toString();
+    }
+
+    // Properties-backed generator (no output buffer; goes through Strings)
+    private String _writeProps(JavaPropsMapper mapper, GenBody body) {
+        Properties props = new Properties();
+        // NOTE: no mapper-level context, so feature must be enabled on factory
+        JavaPropsFactory f = mapper.tokenStreamFactory().rebuild()
+                .configure(StreamWriteFeature.USE_FAST_DOUBLE_WRITER,
+                        mapper.isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER))
+                .build();
+        try (JsonGenerator g = f.createGenerator(ObjectWriteContext.empty(), null, props)) {
+            g.writeStartObject();
+            g.writeName("v");
+            body.write(g);
+            g.writeEndObject();
+        }
+        return props.getProperty("v");
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,9 @@ implementations)
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)
+#722: (properties, toml, yaml) Use `NumberOutput` for writing numbers; respect
+  `StreamWriteFeature.USE_FAST_DOUBLE_WRITER` for `double`/`float` (previously
+  ignored by these modules), writing directly into output buffer where possible
 
 3.2.2 (14-Aug-2026)
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlGenerator.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlGenerator.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import tools.jackson.core.*;
 import tools.jackson.core.base.GeneratorBase;
 import tools.jackson.core.io.IOContext;
+import tools.jackson.core.io.NumberOutput;
 import tools.jackson.core.util.JacksonFeatureSet;
 import tools.jackson.core.util.VersionUtil;
 
@@ -582,14 +583,22 @@ final class TomlGenerator extends GeneratorBase
     @Override
     public JsonGenerator writeNumber(int i) throws JacksonException {
         _verifyValueWrite("write number");
-        _writeRaw(String.valueOf(i));
+        // up to 10 digits and possible minus sign
+        if ((_outputTail + 11) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputInt(i, _outputBuffer, _outputTail);
         return writeValueEnd();
     }
 
     @Override
     public JsonGenerator writeNumber(long l) throws JacksonException {
         _verifyValueWrite("write number");
-        _writeRaw(String.valueOf(l));
+        // up to 19 digits and possible minus sign
+        if ((_outputTail + 20) > _outputEnd) {
+            _flushBuffer();
+        }
+        _outputTail = NumberOutput.outputLong(l, _outputBuffer, _outputTail);
         return writeValueEnd();
     }
 
@@ -599,42 +608,53 @@ final class TomlGenerator extends GeneratorBase
             return writeNull();
         }
         _verifyValueWrite("write number");
-        _writeRaw(String.valueOf(v));
+        _writeRaw(v.toString());
         return writeValueEnd();
     }
 
     @Override
     public JsonGenerator writeNumber(double d) throws JacksonException {
         _verifyValueWrite("write number");
-        _writeRaw(_nonFiniteTomlToken(d, String.valueOf(d)));
+        // Non-finite values need TOML tokens (`nan`/`inf`/`-inf`): Java text
+        // forms (`NaN`/`Infinity`) are not valid TOML and cannot be read back
+        if (NumberOutput.notFinite(d)) {
+            _writeRaw(_nonFiniteTomlToken(d));
+        } else if (isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)) {
+            if ((_outputTail + NumberOutput.MAX_DOUBLE_BYTES) > _outputEnd) {
+                _flushBuffer();
+            }
+            _outputTail = NumberOutput.outputDouble(d, _outputBuffer, _outputTail);
+        } else {
+            _writeRaw(NumberOutput.toString(d, false));
+        }
         return writeValueEnd();
     }
 
     @Override
     public JsonGenerator writeNumber(float f) throws JacksonException {
         _verifyValueWrite("write number");
-        _writeRaw(_nonFiniteTomlToken(f, String.valueOf(f)));
+        if (NumberOutput.notFinite(f)) {
+            _writeRaw(_nonFiniteTomlToken(f));
+        } else if (isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)) {
+            if ((_outputTail + NumberOutput.MAX_FLOAT_BYTES) > _outputEnd) {
+                _flushBuffer();
+            }
+            _outputTail = NumberOutput.outputFloat(f, _outputBuffer, _outputTail);
+        } else {
+            _writeRaw(NumberOutput.toString(f, false));
+        }
         return writeValueEnd();
     }
 
     /**
      * Maps a non-finite floating-point value to the TOML float token
-     * ({@code nan}, {@code inf} or {@code -inf}); finite values are written
-     * using the supplied Java text form. {@code String.valueOf(...)} would
-     * otherwise emit {@code NaN} / {@code Infinity} / {@code -Infinity}, which
-     * are not valid TOML and cannot be read back by the parser.
+     * ({@code nan}, {@code inf} or {@code -inf}).
      */
-    private static String _nonFiniteTomlToken(double d, String finiteForm) {
+    private static String _nonFiniteTomlToken(double d) {
         if (Double.isNaN(d)) {
             return "nan";
         }
-        if (d == Double.POSITIVE_INFINITY) {
-            return "inf";
-        }
-        if (d == Double.NEGATIVE_INFINITY) {
-            return "-inf";
-        }
-        return finiteForm;
+        return (d > 0) ? "inf" : "-inf";
     }
 
     @Override

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlGeneratorNumberTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlGeneratorNumberTest.java
@@ -1,0 +1,193 @@
+package tools.jackson.dataformat.toml;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.io.NumberOutput;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for numeric output of {@code TomlGenerator}: {@code int}/{@code long}
+ * are written via {@code NumberOutput.outputInt/outputLong()} straight into
+ * output buffer; {@code double}/{@code float} likewise when
+ * {@code StreamWriteFeature.USE_FAST_DOUBLE_WRITER} is enabled (and via
+ * {@code Double.toString()}-compatible text when not).
+ */
+public class TomlGeneratorNumberTest extends TomlMapperTestBase
+{
+    private final TomlMapper DEFAULT_MAPPER = newTomlMapper();
+
+    private final TomlMapper FAST_MAPPER = TomlMapper.builder()
+            .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+            .build();
+
+    private final static int[] INTS = new int[] {
+        0, 1, -1, 7, 42, -99, 1000, 123456789, Integer.MAX_VALUE, Integer.MIN_VALUE,
+    };
+
+    private final static long[] LONGS = new long[] {
+        0L, 1L, -1L, 1L << 33, -(1L << 40), 1234567890123456789L, Long.MAX_VALUE, Long.MIN_VALUE,
+    };
+
+    private final static double[] DOUBLES = new double[] {
+        0.0, -0.0, 1.0, -1.0, 1.25, -2.5, 0.1, 0.3, 1e-7, 1.0e20, 1.0e21,
+        123456789.125, Double.MIN_VALUE, Double.MAX_VALUE, Math.PI, -Math.E,
+    };
+
+    private final static float[] FLOATS = new float[] {
+        0.0f, -0.0f, 1.0f, -1.0f, 1.25f, -2.5f, 0.1f, 1.89f, 1e-7f, 1.0e20f,
+        Float.MIN_VALUE, Float.MAX_VALUE, (float) Math.PI,
+    };
+
+    /*
+    /**********************************************************************
+    /* Integers
+    /**********************************************************************
+     */
+
+    @Test
+    public void testInts() {
+        for (int v : INTS) {
+            assertEquals("abc = " + v + "\n", _write(DEFAULT_MAPPER, g -> g.writeNumber(v)));
+        }
+    }
+
+    @Test
+    public void testLongs() {
+        for (long v : LONGS) {
+            assertEquals("abc = " + v + "\n", _write(DEFAULT_MAPPER, g -> g.writeNumber(v)));
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Floating-point
+    /**********************************************************************
+     */
+
+    @Test
+    public void testDoublesDefaultWriter() {
+        for (double d : DOUBLES) {
+            assertEquals("abc = " + Double.toString(d) + "\n",
+                    _write(DEFAULT_MAPPER, g -> g.writeNumber(d)));
+        }
+    }
+
+    @Test
+    public void testDoublesFastWriter() {
+        for (double d : DOUBLES) {
+            assertEquals("abc = " + NumberOutput.toString(d, true) + "\n",
+                    _write(FAST_MAPPER, g -> g.writeNumber(d)));
+        }
+    }
+
+    @Test
+    public void testFloatsDefaultWriter() {
+        for (float f : FLOATS) {
+            assertEquals("abc = " + Float.toString(f) + "\n",
+                    _write(DEFAULT_MAPPER, g -> g.writeNumber(f)));
+        }
+    }
+
+    @Test
+    public void testFloatsFastWriter() {
+        for (float f : FLOATS) {
+            assertEquals("abc = " + NumberOutput.toString(f, true) + "\n",
+                    _write(FAST_MAPPER, g -> g.writeNumber(f)));
+        }
+    }
+
+    // Non-finite values must still be written as TOML tokens with fast writer
+    @Test
+    public void testNonFiniteFastWriter() {
+        assertEquals("abc = nan\n", _write(FAST_MAPPER, g -> g.writeNumber(Double.NaN)));
+        assertEquals("abc = inf\n", _write(FAST_MAPPER, g -> g.writeNumber(Double.POSITIVE_INFINITY)));
+        assertEquals("abc = -inf\n", _write(FAST_MAPPER, g -> g.writeNumber(Double.NEGATIVE_INFINITY)));
+        assertEquals("abc = nan\n", _write(FAST_MAPPER, g -> g.writeNumber(Float.NaN)));
+        assertEquals("abc = inf\n", _write(FAST_MAPPER, g -> g.writeNumber(Float.POSITIVE_INFINITY)));
+        assertEquals("abc = -inf\n", _write(FAST_MAPPER, g -> g.writeNumber(Float.NEGATIVE_INFINITY)));
+    }
+
+    /*
+    /**********************************************************************
+    /* Buffer boundaries
+    /**********************************************************************
+     */
+
+    // Write enough values (in inline arrays and as top-level entries) to
+    // cross the output buffer boundary multiple times
+    @Test
+    public void testManyValuesAcrossBufferBoundary() {
+        for (TomlMapper mapper : new TomlMapper[] { DEFAULT_MAPPER, FAST_MAPPER }) {
+            final boolean fast = mapper.isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER);
+            final int ROWS = 1500;
+            StringBuilder exp = new StringBuilder();
+            for (int i = 0; i < ROWS; ++i) {
+                exp.append("i").append(i).append(" = ").append(_int(i)).append('\n');
+                exp.append("l").append(i).append(" = ").append(_long(i)).append('\n');
+                exp.append("d").append(i).append(" = ")
+                    .append(NumberOutput.toString(_double(i), fast)).append('\n');
+                exp.append("f").append(i).append(" = ")
+                    .append(NumberOutput.toString(_float(i), fast)).append('\n');
+            }
+            String expected = exp.toString();
+            assertEquals(expected, _writeRows(mapper, ROWS, false));
+            assertEquals(expected, _writeRows(mapper, ROWS, true));
+        }
+    }
+
+    private static int _int(int i) { return (i * 7919) * ((i & 1) == 0 ? 1 : -1); }
+    private static long _long(int i) { return ((long) i * 1_000_000_007L) * ((i & 2) == 0 ? 1 : -1); }
+    private static double _double(int i) {
+        return (i * 1.000001) / 7.0 * ((i & 1) == 0 ? 1 : -1) + (i % 5) * 1e-9;
+    }
+    private static float _float(int i) {
+        return (i * 1.0001f) / 3.0f * ((i & 2) == 0 ? 1 : -1) + (i % 3) * 1e-5f;
+    }
+
+    private String _writeRows(TomlMapper mapper, int rows, boolean useStream)
+    {
+        StringWriter sw = new StringWriter();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (JsonGenerator g = useStream ? mapper.createGenerator(bytes) : mapper.createGenerator(sw)) {
+            g.writeStartObject();
+            for (int i = 0; i < rows; ++i) {
+                g.writeName("i" + i);
+                g.writeNumber(_int(i));
+                g.writeName("l" + i);
+                g.writeNumber(_long(i));
+                g.writeName("d" + i);
+                g.writeNumber(_double(i));
+                g.writeName("f" + i);
+                g.writeNumber(_float(i));
+            }
+            g.writeEndObject();
+        }
+        return useStream ? new String(bytes.toByteArray(), StandardCharsets.UTF_8) : sw.toString();
+    }
+
+    /*
+    /**********************************************************************
+    /* Helpers
+    /**********************************************************************
+     */
+
+    private interface GenBody { void write(JsonGenerator g); }
+
+    private String _write(TomlMapper mapper, GenBody body) {
+        StringWriter w = new StringWriter();
+        try (JsonGenerator g = mapper.createGenerator(w)) {
+            g.writeStartObject();
+            g.writeName("abc");
+            body.write(g);
+            g.writeEndObject();
+        }
+        return w.toString();
+    }
+}

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLGenerator.java
@@ -11,6 +11,7 @@ import tools.jackson.core.*;
 
 import tools.jackson.core.base.GeneratorBase;
 import tools.jackson.core.io.IOContext;
+import tools.jackson.core.io.NumberOutput;
 import tools.jackson.core.json.DupDetector;
 import tools.jackson.core.util.JacksonFeatureSet;
 import tools.jackson.core.util.SimpleStreamWriteContext;
@@ -661,7 +662,7 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(int v) throws JacksonException
     {
         _verifyValueWrite("write number");
-        _writeScalar(String.valueOf(v), "int", STYLE_SCALAR);
+        _writeScalar(Integer.toString(v), "int", STYLE_SCALAR);
         return this;
     }
 
@@ -673,7 +674,7 @@ public class YAMLGenerator extends GeneratorBase
             return writeNumber((int) l);
         }
         _verifyValueWrite("write number");
-        _writeScalar(String.valueOf(l), "long", STYLE_SCALAR);
+        _writeScalar(Long.toString(l), "long", STYLE_SCALAR);
         return this;
     }
 
@@ -692,25 +693,18 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(double d) throws JacksonException
     {
         _verifyValueWrite("write number");
-        if (isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
+        if (NumberOutput.notFinite(d) && isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
             if (Double.isNaN(d)) {
                 _writeScalar(".nan", "double", STYLE_PLAIN);
+            } else if (d > 0.0) {
+                _writeScalar(".inf", "double", STYLE_PLAIN);
+            } else {
+                _writeScalar("-.inf", "double", STYLE_PLAIN);
             }
-            else if (Double.isInfinite(d)) {
-                if (d > 0.0) {
-                    _writeScalar(".inf", "double", STYLE_PLAIN);
-                }
-                else {
-                    _writeScalar("-.inf", "double", STYLE_PLAIN);
-                }
-            }
-            else {
-                _writeScalar(String.valueOf(d), "double", STYLE_SCALAR);
-            }
+            return this;
         }
-        else {
-            _writeScalar(String.valueOf(d), "double", STYLE_SCALAR);
-        }
+        _writeScalar(NumberOutput.toString(d, isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)),
+                "double", STYLE_SCALAR);
         return this;
     }
 
@@ -718,25 +712,18 @@ public class YAMLGenerator extends GeneratorBase
     public JsonGenerator writeNumber(float f) throws JacksonException
     {
         _verifyValueWrite("write number");
-        if (isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
+        if (NumberOutput.notFinite(f) && isEnabled(YAMLWriteFeature.USE_YAML_NONFINITE_NOTATION)) {
             if (Float.isNaN(f)) {
                 _writeScalar(".nan", "float", STYLE_PLAIN);
+            } else if (f > 0.0f) {
+                _writeScalar(".inf", "float", STYLE_PLAIN);
+            } else {
+                _writeScalar("-.inf", "float", STYLE_PLAIN);
             }
-            else if (Float.isInfinite(f)) {
-                if (f > 0.0f) {
-                    _writeScalar(".inf", "float", STYLE_PLAIN);
-                }
-                else {
-                    _writeScalar("-.inf", "float", STYLE_PLAIN);
-                }
-            }
-            else {
-                _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
-            }
+            return this;
         }
-        else {  
-            _writeScalar(String.valueOf(f), "float", STYLE_SCALAR);
-        }
+        _writeScalar(NumberOutput.toString(f, isEnabled(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)),
+                "float", STYLE_SCALAR);
         return this;
     }
 

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAMLGeneratorNumberTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/ser/YAMLGeneratorNumberTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.io.NumberOutput;
 import tools.jackson.dataformat.yaml.ModuleTestBase;
 import tools.jackson.dataformat.yaml.YAMLFactory;
 import tools.jackson.dataformat.yaml.YAMLMapper;
@@ -29,8 +30,12 @@ public class YAMLGeneratorNumberTest extends ModuleTestBase
     private interface GenBody { void write(JsonGenerator g) throws Exception; }
 
     private String _doc(GenBody body) throws Exception {
+        return _doc(MAPPER, body);
+    }
+
+    private String _doc(YAMLMapper mapper, GenBody body) throws Exception {
         StringWriter w = new StringWriter();
-        try (JsonGenerator g = MAPPER.createGenerator(w)) {
+        try (JsonGenerator g = mapper.createGenerator(w)) {
             body.write(g);
         }
         return w.toString();
@@ -100,6 +105,46 @@ public class YAMLGeneratorNumberTest extends ModuleTestBase
     public void testWriteNumberAsString() throws Exception {
         String yaml = _doc(g -> g.writeNumber("4321"));
         assertEquals(4321, (int) MAPPER.readValue(yaml, Integer.class));
+    }
+
+    private final static double[] DOUBLES = new double[] {
+        0.0, -0.0, 1.0, -1.0, 1.25, -2.5, 0.1, 0.3, 1e-7, 1.0e20, 1.0e21,
+        123456789.125, Double.MIN_VALUE, Double.MAX_VALUE, Math.PI, -Math.E,
+    };
+
+    private final static float[] FLOATS = new float[] {
+        0.0f, -0.0f, 1.0f, -1.0f, 1.25f, -2.5f, 0.1f, 1.89f, 1e-7f, 1.0e20f,
+        Float.MIN_VALUE, Float.MAX_VALUE, (float) Math.PI,
+    };
+
+    // Default writer: text must match `Double.toString()`/`Float.toString()`
+    @Test
+    public void testDoublesAndFloatsDefaultWriter() throws Exception {
+        for (double d : DOUBLES) {
+            assertEquals("--- " + Double.toString(d) + "\n", _doc(g -> g.writeNumber(d)));
+        }
+        for (float f : FLOATS) {
+            assertEquals("--- " + Float.toString(f) + "\n", _doc(g -> g.writeNumber(f)));
+        }
+    }
+
+    // Fast writer (Schubfach): text must match `NumberOutput.toString(v, true)`
+    @Test
+    public void testDoublesAndFloatsFastWriter() throws Exception {
+        YAMLMapper fast = YAMLMapper.builder()
+                .enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER)
+                .build();
+        for (double d : DOUBLES) {
+            assertEquals("--- " + NumberOutput.toString(d, true) + "\n",
+                    _doc(fast, g -> g.writeNumber(d)));
+        }
+        for (float f : FLOATS) {
+            assertEquals("--- " + NumberOutput.toString(f, true) + "\n",
+                    _doc(fast, g -> g.writeNumber(f)));
+        }
+        // and non-finite notation must be unaffected
+        assertTrue(_doc(fast, g -> g.writeNumber(Double.NaN)).contains(".nan"));
+        assertTrue(_doc(fast, g -> g.writeNumber(Float.NEGATIVE_INFINITY)).contains("-.inf"));
     }
 
     /*


### PR DESCRIPTION
Follow-up to #721 (CSV), extending `NumberOutput` usage to the other three modules. Previously Properties, TOML and YAML all wrote numbers via `String.valueOf(...)` and ignored `StreamWriteFeature.USE_FAST_DOUBLE_WRITER` entirely.

**TOML** (`TomlGenerator`) and **Properties** (`WriterBackedGenerator`) own a `char[]` output buffer, so:
- `int`/`long` → `NumberOutput.outputInt/outputLong()` straight into the buffer
- `double`/`float` → `NumberOutput.outputDouble/outputFloat(char[])` (Schubfach) when `USE_FAST_DOUBLE_WRITER` is enabled; `NumberOutput.toString(v, false)` (= `Double.toString()`) otherwise
- TOML still maps non-finite values to `nan`/`inf`/`-inf` — the check now runs before any text is produced, instead of building a `String` first and discarding it

**Properties** base class `JavaPropsGenerator` gains non-abstract `_writeUnescapedEntry(int/long/double/float)` hooks with `String`-based defaults (`@since 3.3`), so `PropertiesBackedGenerator` — and any external sub-class — keeps working unchanged while `WriterBackedGenerator` overrides them.

**YAML** is bound to `String` scalars by the SnakeYAML emitter, so it now uses `NumberOutput.toString(v, useFast)` to honour the feature; non-finite handling (`.nan`/`.inf`) is unchanged.

Tests: new `TomlGeneratorNumberTest` and `NumberGenerationTest` (properties), plus fast-writer cases in `YAMLGeneratorNumberTest` — covering default vs. fast output, non-finite values, `Writer` and `OutputStream` targets, the `Properties`-backed generator, and runs that cross the output buffer boundary. Fast-path expectations are checked against `NumberOutput.toString(v, true)` since JDK < 19 `Float.toString()` isn't always shortest-repr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
