### PR TITLE
Single-pass String value writing in CsvEncoder; native char[] path; primitive array appends

### DIFF
--- a/csv/src/main/java/tools/jackson/dataformat/csv/CsvGenerator.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/CsvGenerator.java
@@ -535,7 +535,7 @@ public class CsvGenerator extends GeneratorBase
         _verifyValueWrite("write String value");
         if (!_skipValue) {
             if (!_arraySeparator.isEmpty()) {
-                _addToArray(new String(text, offset, len));
+                _addToArray(text, offset, len);
             // 26-Aug-2024, tatu: [dataformats-text#495] Decorations!
             } else if (_nextColumnDecorator != null) {
                 String str = new String(text, offset, len);
@@ -762,7 +762,7 @@ public class CsvGenerator extends GeneratorBase
         _verifyValueWrite("write number");
         if (!_skipValue) {
             if (!_arraySeparator.isEmpty()) {
-                _addToArray(String.valueOf(v));
+                _addToArray(v);
             // 26-Aug-2024, tatu: [dataformats-text#495] Decorations?
             } else if (_nextColumnDecorator != null) {
                 _writer.write(_columnIndex(),
@@ -784,7 +784,7 @@ public class CsvGenerator extends GeneratorBase
         _verifyValueWrite("write number");
         if (!_skipValue) {
             if (!_arraySeparator.isEmpty()) {
-                _addToArray(String.valueOf(v));
+                _addToArray(v);
             // 26-Aug-2024, tatu: [dataformats-text#495] Decorations?
             } else if (_nextColumnDecorator != null) {
                 _writer.write(_columnIndex(),
@@ -824,7 +824,7 @@ public class CsvGenerator extends GeneratorBase
         _verifyValueWrite("write number");
         if (!_skipValue) {
             if (!_arraySeparator.isEmpty()) {
-                _addToArray(String.valueOf(v));
+                _addToArray(v);
             // 26-Aug-2024, tatu: [dataformats-text#495] Decorations?
             } else if (_nextColumnDecorator != null) {
                 _writer.write(_columnIndex(),
@@ -842,7 +842,7 @@ public class CsvGenerator extends GeneratorBase
         _verifyValueWrite("write number");
         if (!_skipValue) {
             if (!_arraySeparator.isEmpty()) {
-                _addToArray(String.valueOf(v));
+                _addToArray(v);
             // 26-Aug-2024, tatu: [dataformats-text#495] Decorations?
             } else if (_nextColumnDecorator != null) {
                 _writer.write(_columnIndex(),
@@ -1014,6 +1014,54 @@ public class CsvGenerator extends GeneratorBase
     }
     
     protected void _addToArray(char[] value) {
+        if (_arrayElements > 0) {
+            _arrayContents.append(_arraySeparator);
+        }
+        ++_arrayElements;
+        _arrayContents.append(value);
+    }
+
+    // @since 3.3
+    protected void _addToArray(char[] value, int offset, int len) {
+        if (_arrayElements > 0) {
+            _arrayContents.append(_arraySeparator);
+        }
+        ++_arrayElements;
+        _arrayContents.append(value, offset, len);
+    }
+
+    // Primitive number variants append directly, avoiding intermediate `String`;
+    // output text is the same as with `String.valueOf()`.
+
+    // @since 3.3
+    protected void _addToArray(int value) {
+        if (_arrayElements > 0) {
+            _arrayContents.append(_arraySeparator);
+        }
+        ++_arrayElements;
+        _arrayContents.append(value);
+    }
+
+    // @since 3.3
+    protected void _addToArray(long value) {
+        if (_arrayElements > 0) {
+            _arrayContents.append(_arraySeparator);
+        }
+        ++_arrayElements;
+        _arrayContents.append(value);
+    }
+
+    // @since 3.3
+    protected void _addToArray(double value) {
+        if (_arrayElements > 0) {
+            _arrayContents.append(_arraySeparator);
+        }
+        ++_arrayElements;
+        _arrayContents.append(value);
+    }
+
+    // @since 3.3
+    protected void _addToArray(float value) {
         if (_arrayElements > 0) {
             _arrayContents.append(_arraySeparator);
         }

--- a/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvEncoder.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvEncoder.java
@@ -384,23 +384,7 @@ public class CsvEncoder
     {
         // easy case: all in order
         if (columnIndex == _nextColumnToWrite) {
-            // inlined 'appendValue(String)`
-            if (_outputTail >= _outputEnd) {
-                _flushBuffer();
-            }
-            if (_nextColumnToWrite > 0) {
-                appendColumnSeparator();
-            }
-            final int len = value.length();
-            if (_cfgAlwaysQuoteStrings || _mayNeedQuotes(value, len, columnIndex)) {
-                if (_cfgEscapeCharacter > 0) {
-                    _writeQuotedAndEscaped(value, (char) _cfgEscapeCharacter);
-                } else {
-                    _writeQuoted(value);
-                }
-            } else {
-                writeRaw(value);
-            }
+            appendValue(value);
             ++_nextColumnToWrite;
             return;
         }
@@ -409,8 +393,13 @@ public class CsvEncoder
 
     public final void write(int columnIndex, char[] ch, int offset, int len) throws JacksonException
     {
-        // !!! TODO: optimize
-        write(columnIndex, new String(ch, offset, len));
+        // easy case: all in order
+        if (columnIndex == _nextColumnToWrite) {
+            appendValue(ch, offset, len);
+            ++_nextColumnToWrite;
+            return;
+        }
+        _buffer(columnIndex, BufferedValue.buffered(new String(ch, offset, len)));
     }
 
     public final void write(int columnIndex, int value) throws JacksonException
@@ -598,17 +587,95 @@ public class CsvEncoder
         if (_nextColumnToWrite > 0) {
             appendColumnSeparator();
         }
-        // First: determine if we need quotes; simple heuristics;
-        // only check for short Strings, stop if something found
         final int len = value.length();
-        if (_cfgAlwaysQuoteStrings || _mayNeedQuotes(value, len, _nextColumnToWrite)) {
-            if (_cfgEscapeCharacter > 0) {
-                _writeQuotedAndEscaped(value, (char) _cfgEscapeCharacter);
-            } else {
-                _writeQuoted(value);
-            }
-        } else {
+        // First: cases where no scanning of content is needed
+        if (_cfgAlwaysQuoteStrings) {
+            _writeQuotedValue(value);
+            return;
+        }
+        if (_cfgQuoteCharacter < 0) { // quoting disabled
             writeRaw(value);
+            return;
+        }
+        if (_needsQuotesWithoutScan(value, len, _nextColumnToWrite)) {
+            _writeQuotedValue(value);
+            return;
+        }
+        // Common case is that of no quoting needed: so make a speculative copy
+        // into output buffer and scan that (single pass over content, instead of
+        // scanning String and then copying). If quoting turns out to be needed,
+        // quoted write simply overwrites the speculative copy.
+        if ((_outputTail + len) > _outputEnd) {
+            if (len > _outputEnd) { // too long to fit even in empty buffer
+                if (_needsQuoting(value)) {
+                    _writeQuotedValue(value);
+                } else {
+                    writeRaw(value);
+                }
+                return;
+            }
+            _flushBuffer();
+        }
+        value.getChars(0, len, _outputBuffer, _outputTail);
+        if (_needsQuoting(_outputBuffer, _outputTail, len)) {
+            _writeQuotedValue(value);
+        } else {
+            _outputTail += len;
+        }
+    }
+
+    /**
+     * Variant of {@link #appendValue(String)} for {@code char[]} input:
+     * common case of no quoting needed is handled without constructing
+     * a {@code String}.
+     *
+     * @since 3.3
+     */
+    protected void appendValue(char[] ch, int offset, int len) throws JacksonException
+    {
+        if (_outputTail >= _outputEnd) {
+            _flushBuffer();
+        }
+        if (_nextColumnToWrite > 0) {
+            appendColumnSeparator();
+        }
+        if (_cfgAlwaysQuoteStrings) {
+            _writeQuotedValue(new String(ch, offset, len));
+            return;
+        }
+        if (_cfgQuoteCharacter < 0) { // quoting disabled
+            writeRaw(ch, offset, len);
+            return;
+        }
+        if (_needsQuotesWithoutScan(ch, offset, len, _nextColumnToWrite)) {
+            _writeQuotedValue(new String(ch, offset, len));
+            return;
+        }
+        if ((_outputTail + len) > _outputEnd) {
+            if (len > _outputEnd) { // too long to fit even in empty buffer
+                if (_needsQuoting(ch, offset, len)) {
+                    _writeQuotedValue(new String(ch, offset, len));
+                } else {
+                    writeRaw(ch, offset, len);
+                }
+                return;
+            }
+            _flushBuffer();
+        }
+        System.arraycopy(ch, offset, _outputBuffer, _outputTail, len);
+        if (_needsQuoting(_outputBuffer, _outputTail, len)) {
+            _writeQuotedValue(new String(ch, offset, len));
+        } else {
+            _outputTail += len;
+        }
+    }
+
+    private void _writeQuotedValue(String value) throws JacksonException
+    {
+        if (_cfgEscapeCharacter > 0) {
+            _writeQuotedAndEscaped(value, (char) _cfgEscapeCharacter);
+        } else {
+            _writeQuoted(value);
         }
     }
 
@@ -1144,10 +1211,46 @@ public class CsvEncoder
         if (_cfgQuoteCharacter < 0) {
             return false;
         }
+        if (_needsQuotesWithoutScan(value, length, columnIndex)) {
+            return true;
+        }
+        return _needsQuoting(value);
+    }
+
+    /**
+     * Checks that can determine need for quoting without scanning content
+     * (leading/trailing whitespace, comment marker, length, empty String).
+     * Returns {@code false} if content scan ({@link #_needsQuoting}) is
+     * still needed to decide.
+     *
+     * @since 3.3
+     */
+    protected boolean _needsQuotesWithoutScan(String value, int length, int columnIndex)
+    {
+        if (length == 0) {
+            return _needsQuotesWithoutScan((char) 0, (char) 0, length, columnIndex);
+        }
+        return _needsQuotesWithoutScan(value.charAt(0), value.charAt(length - 1),
+                length, columnIndex);
+    }
+
+    /**
+     * @since 3.3
+     */
+    protected boolean _needsQuotesWithoutScan(char[] ch, int offset, int length, int columnIndex)
+    {
+        if (length == 0) {
+            return _needsQuotesWithoutScan((char) 0, (char) 0, length, columnIndex);
+        }
+        return _needsQuotesWithoutScan(ch[offset], ch[offset + length - 1],
+                length, columnIndex);
+    }
+
+    // NOTE: `first` and `last` only meaningful if `length > 0`
+    private boolean _needsQuotesWithoutScan(char first, char last, int length, int columnIndex)
+    {
         // [dataformats-text#210]: check for leading/trailing whitespace
         if (_cfgQuoteLeadingTrailingWhitespace && length > 0) {
-            char first = value.charAt(0);
-            char last = value.charAt(length - 1);
             if (first <= ' ' || last <= ' ') {
                 return true;
             }
@@ -1156,25 +1259,57 @@ public class CsvEncoder
         if (_cfgOptimalQuoting) {
             // 31-Dec-2014, tatu: Comment lines start with # so quote if starts with #
             // 28-May-2021, tatu: As per [dataformats-text#270] only check if first column
-            if (_cfgAllowsComments && (columnIndex == 0)
-                && (length > 0) && (value.charAt(0) == '#')) {
-                return true;
-            }
-            if (_cfgEscapeCharacter > 0) {
-                return _needsQuotingStrict(value, _cfgEscapeCharacter);
-            }
-            return _needsQuotingStrict(value);
+            return _cfgAllowsComments && (columnIndex == 0)
+                && (length > 0) && (first == '#');
         }
         if (length > _cfgMaxQuoteCheckChars) {
             return true;
         }
         if (_cfgEscapeCharacter > 0) {
+            return false;
+        }
+        return _cfgAlwaysQuoteEmptyStrings && length == 0;
+    }
+
+    /**
+     * Content scan to determine whether quoting is needed; strict or loose
+     * depending on configuration.
+     *
+     * @since 3.3
+     */
+    protected boolean _needsQuoting(String value)
+    {
+        if (_cfgOptimalQuoting) {
+            if (_cfgEscapeCharacter > 0) {
+                return _needsQuotingStrict(value, _cfgEscapeCharacter);
+            }
+            return _needsQuotingStrict(value);
+        }
+        if (_cfgEscapeCharacter > 0) {
             return _needsQuotingLoose(value, _cfgEscapeCharacter);
         }
-        if (_cfgAlwaysQuoteEmptyStrings && length == 0) {
-            return true;
-        }
         return _needsQuotingLoose(value);
+    }
+
+    /**
+     * Content scan over a {@code char[]} region; same logic as
+     * {@link #_needsQuoting(String)}.
+     *
+     * @since 3.3
+     */
+    protected boolean _needsQuoting(char[] ch, int offset, int len)
+    {
+        final int end = offset + len;
+        if (_cfgOptimalQuoting) {
+            if (_cfgEscapeCharacter > 0) {
+                return _needsQuotingStrict(ch, offset, end, _cfgEscapeCharacter);
+            }
+            return _needsQuotingStrict(ch, offset, end);
+        }
+        if (_cfgEscapeCharacter > 0) {
+            return _needsQuotingLoose(ch, offset, end, _cfgEscapeCharacter);
+        }
+        return _needsQuotingLoose(ch, offset, end);
     }
 
     /**
@@ -1257,6 +1392,77 @@ public class CsvEncoder
                         || (c < escLen && escCodes[c] != 0)
                         || (c == lfFirst)
                         // Per RFC 4180: must quote if contains LF or CR
+                        || (c == '\n') || (c == '\r')) {
+                    return true;
+                }
+            } else if (c == esc) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean _needsQuotingLoose(char[] ch, int i, int end)
+    {
+        final char esc1 = _cfgQuoteCharEscapeChar;
+        final char esc2 = _cfgControlCharEscapeChar;
+        final int minSafe = _cfgMinSafeChar;
+
+        for (; i < end; ++i) {
+            char c = ch[i];
+            if ((c < minSafe) || (c == esc1) || (c == esc2)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean _needsQuotingLoose(char[] ch, int i, int end, int esc)
+    {
+        final int minSafe = _cfgMinSafeChar;
+        for (; i < end; ++i) {
+            int c = ch[i];
+            if ((c < minSafe) || (c == esc)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean _needsQuotingStrict(char[] ch, int i, int end)
+    {
+        final int minSafe = _cfgMinSafeChar;
+        final int[] escCodes = _outputEscapes;
+        final int escLen = escCodes.length;
+        final int lfFirst = (_cfgLineSeparatorLength == 0) ? 0 : _cfgLineSeparator[0];
+
+        for (; i < end; ++i) {
+            int c = ch[i];
+            if (c < minSafe) {
+                if (c == _cfgColumnSeparator || c == _cfgQuoteCharacter
+                        || (c < escLen && escCodes[c] != 0)
+                        || (c == lfFirst)
+                        || (c == '\n') || (c == '\r')) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean _needsQuotingStrict(char[] ch, int i, int end, int esc)
+    {
+        final int minSafe = _cfgMinSafeChar;
+        final int[] escCodes = _outputEscapes;
+        final int escLen = escCodes.length;
+        final int lfFirst = (_cfgLineSeparatorLength == 0) ? 0 : _cfgLineSeparator[0];
+
+        for (; i < end; ++i) {
+            int c = ch[i];
+            if (c < minSafe) {
+                if (c == _cfgColumnSeparator || c == _cfgQuoteCharacter
+                        || (c < escLen && escCodes[c] != 0)
+                        || (c == lfFirst)
                         || (c == '\n') || (c == '\r')) {
                     return true;
                 }

--- a/csv/src/test/java/tools/jackson/dataformat/csv/ser/ArrayWriteTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/ser/ArrayWriteTest.java
@@ -52,6 +52,54 @@ public class ArrayWriteTest extends ModuleTestBase
         assertEquals("foo,1;2;3,stuff", csv);
     }
 
+    @JsonPropertyOrder({"id", "longs", "doubles", "floats", "shorts"})
+    static class NumberArrays {
+        public String id = "n";
+        public long[] longs = new long[] { 0L, -1L, 1L << 40 };
+        public double[] doubles = new double[] { -0.0, 1.25, 1e-7, Double.NaN };
+        public float[] floats = new float[] { 1.89f, 1.4e-45f, Float.POSITIVE_INFINITY };
+        public short[] shorts = new short[] { -1, 300 };
+    }
+
+    // Numeric array elements are appended directly (no intermediate String),
+    // output must match `String.valueOf()`. NOTE: kept short enough not to
+    // trigger quoting of long values
+    @Test
+    public void testNumberArrays() throws Exception
+    {
+        NumberArrays input = new NumberArrays();
+        String csv = MAPPER.writerWithSchemaFor(NumberArrays.class)
+                .writeValueAsString(input)
+                .trim();
+        assertEquals("n,0;-1;1099511627776"
+                + ",-0.0;1.25;1.0E-7;NaN"
+                + ",1.89;1.4E-45;Infinity"
+                + ",-1;300", csv);
+    }
+
+    @Test
+    public void testCharArrayElements() throws Exception
+    {
+        CsvSchema schema = CsvSchema.builder()
+                .addColumn("id")
+                .addArrayColumn("values", ";")
+                .build();
+        java.io.StringWriter sw = new java.io.StringWriter();
+        try (tools.jackson.core.JsonGenerator g = MAPPER.writer(schema).createGenerator(sw)) {
+            g.writeStartObject();
+            g.writeName("id");
+            g.writeString("foo");
+            g.writeName("values");
+            g.writeStartArray();
+            g.writeString("xxabcyy".toCharArray(), 2, 3);
+            g.writeString("def");
+            g.writeString("ghi".toCharArray(), 0, 3);
+            g.writeEndArray();
+            g.writeEndObject();
+        }
+        assertEquals("foo,abc;def;ghi\n", sw.toString());
+    }
+
     @Test
     public void testSeparatorOverride() throws Exception
     {

--- a/csv/src/test/java/tools/jackson/dataformat/csv/ser/CSVStringQuotingModesTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/ser/CSVStringQuotingModesTest.java
@@ -1,0 +1,273 @@
+package tools.jackson.dataformat.csv.ser;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonGenerator;
+
+import tools.jackson.core.type.TypeReference;
+
+import tools.jackson.databind.MappingIterator;
+
+import tools.jackson.dataformat.csv.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@code CsvEncoder} String value writing across quoting modes:
+ * the common "no quoting needed" case is written with a single pass
+ * (speculative copy into output buffer, then scan), with {@code char[]}
+ * input handled without constructing a {@code String}. Output must be
+ * identical for {@code writeString(String)}, {@code writeString(char[],int,int)}
+ * and the buffered (reordered column) path, in every mode.
+ */
+public class CSVStringQuotingModesTest extends ModuleTestBase
+{
+    private final CsvMapper MAPPER = mapperForCsv();
+
+    private final static String LONG_PLAIN = _repeat('x', 30); // > DEFAULT_MAX_QUOTE_CHECK (24)
+    private final static String HUGE_PLAIN = _repeat('y', 2500); // > output buffer (2000)
+    private final static String HUGE_COMMA = _repeat('z', 1200) + "," + _repeat('z', 1300);
+    private final static String NEAR_BUFFER = _repeat('w', 1990); // forces flush before copy
+
+    private final static String[] VALUES = new String[] {
+        "", "abc", "a,b", "a\"b", "a\nb", "a\rb", " abc", "abc ", " ", "#abc", "a#b",
+        "a\\b", "éè", "日本語", "a\tb",
+        LONG_PLAIN, LONG_PLAIN + ",", HUGE_PLAIN, HUGE_COMMA, NEAR_BUFFER,
+    };
+
+    private static String _repeat(char c, int n) {
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; ++i) {
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private final static CsvSchema SCHEMA = CsvSchema.builder()
+            .addColumn("id").addColumn("value").build();
+    // "value" first so it has to go through buffered path when written second
+    private final static CsvSchema REORDERED = CsvSchema.builder()
+            .addColumn("value").addColumn("id").build();
+
+    /*
+    /**********************************************************************
+    /* Hard-coded expectations
+    /**********************************************************************
+     */
+
+    @Test
+    public void testDefaultMode() throws Exception {
+        assertEquals("id,abc\n", _write(MAPPER, SCHEMA, "abc"));
+        assertEquals("id,\"a,b\"\n", _write(MAPPER, SCHEMA, "a,b"));
+        assertEquals("id,\"a\"\"b\"\n", _write(MAPPER, SCHEMA, "a\"b"));
+        assertEquals("id,\"a\nb\"\n", _write(MAPPER, SCHEMA, "a\nb"));
+        assertEquals("id,\n", _write(MAPPER, SCHEMA, ""));
+        // loose mode: Strings longer than max-check-length are quoted without scanning
+        assertEquals("id,\"" + LONG_PLAIN + "\"\n", _write(MAPPER, SCHEMA, LONG_PLAIN));
+        assertEquals("id,\"" + HUGE_PLAIN + "\"\n", _write(MAPPER, SCHEMA, HUGE_PLAIN));
+    }
+
+    @Test
+    public void testStrictMode() throws Exception {
+        CsvMapper strict = CsvMapper.builder()
+                .enable(CsvWriteFeature.STRICT_CHECK_FOR_QUOTING).build();
+        assertEquals("id,abc\n", _write(strict, SCHEMA, "abc"));
+        assertEquals("id,\"a,b\"\n", _write(strict, SCHEMA, "a,b"));
+        // strict mode: long Strings scanned; not quoted if not needed
+        assertEquals("id," + LONG_PLAIN + "\n", _write(strict, SCHEMA, LONG_PLAIN));
+        assertEquals("id," + HUGE_PLAIN + "\n", _write(strict, SCHEMA, HUGE_PLAIN));
+        assertEquals("id,\"" + HUGE_COMMA + "\"\n", _write(strict, SCHEMA, HUGE_COMMA));
+        assertEquals("id," + NEAR_BUFFER + "\n", _write(strict, SCHEMA, NEAR_BUFFER));
+        // comment marker only quoted in first column
+        assertEquals("\"#abc\",id\n", _write(strict, REORDERED.withComments(), "#abc"));
+        assertEquals("id,#abc\n", _write(strict, SCHEMA.withComments(), "#abc"));
+    }
+
+    @Test
+    public void testQuotingDisabled() throws Exception {
+        CsvSchema noQuotes = SCHEMA.withoutQuoteChar();
+        assertEquals("id,a,b\n", _write(MAPPER, noQuotes, "a,b"));
+        assertEquals("id," + HUGE_COMMA + "\n", _write(MAPPER, noQuotes, HUGE_COMMA));
+    }
+
+    @Test
+    public void testAlwaysQuote() throws Exception {
+        CsvMapper always = CsvMapper.builder()
+                .enable(CsvWriteFeature.ALWAYS_QUOTE_STRINGS).build();
+        assertEquals("\"id\",\"abc\"\n", _write(always, SCHEMA, "abc"));
+        assertEquals("\"id\",\"\"\n", _write(always, SCHEMA, ""));
+    }
+
+    @Test
+    public void testEmptyAndWhitespace() throws Exception {
+        CsvMapper m = CsvMapper.builder()
+                .enable(CsvWriteFeature.ALWAYS_QUOTE_EMPTY_STRINGS)
+                .enable(CsvWriteFeature.QUOTE_STRINGS_WITH_LEADING_TRAILING_WHITESPACE)
+                .build();
+        assertEquals("id,\"\"\n", _write(m, SCHEMA, ""));
+        assertEquals("id,\" abc\"\n", _write(m, SCHEMA, " abc"));
+        assertEquals("id,\"abc \"\n", _write(m, SCHEMA, "abc "));
+        assertEquals("id,abc\n", _write(m, SCHEMA, "abc"));
+    }
+
+    @Test
+    public void testEscapeChar() throws Exception {
+        CsvSchema esc = SCHEMA.withEscapeChar('\\');
+        assertEquals("id,abc\n", _write(MAPPER, esc, "abc"));
+        assertEquals("id,\"a\\\\b\"\n", _write(MAPPER, esc, "a\\b"));
+        // quote char is doubled by default, even with escape char configured
+        assertEquals("id,\"a\"\"b\"\n", _write(MAPPER, esc, "a\"b"));
+        CsvMapper escQuotes = CsvMapper.builder()
+                .enable(CsvWriteFeature.ESCAPE_QUOTE_CHAR_WITH_ESCAPE_CHAR).build();
+        assertEquals("id,\"a\\\"b\"\n", _write(escQuotes, esc, "a\"b"));
+    }
+
+    /*
+    /**********************************************************************
+    /* Cross-checks: String vs char[] vs buffered, all modes; round-trip
+    /**********************************************************************
+     */
+
+    @Test
+    public void testAllModesConsistent() throws Exception
+    {
+        List<CsvMapper> mappers = new ArrayList<>();
+        mappers.add(MAPPER);
+        mappers.add(CsvMapper.builder().enable(CsvWriteFeature.STRICT_CHECK_FOR_QUOTING).build());
+        mappers.add(CsvMapper.builder().enable(CsvWriteFeature.ALWAYS_QUOTE_STRINGS).build());
+        mappers.add(CsvMapper.builder()
+                .enable(CsvWriteFeature.ALWAYS_QUOTE_EMPTY_STRINGS)
+                .enable(CsvWriteFeature.QUOTE_STRINGS_WITH_LEADING_TRAILING_WHITESPACE)
+                .build());
+        mappers.add(CsvMapper.builder()
+                .enable(CsvWriteFeature.STRICT_CHECK_FOR_QUOTING)
+                .enable(CsvWriteFeature.QUOTE_STRINGS_WITH_LEADING_TRAILING_WHITESPACE)
+                .enable(CsvWriteFeature.ESCAPE_CONTROL_CHARS_WITH_ESCAPE_CHAR)
+                .build());
+        List<UnaryOperator<CsvSchema>> schemaVariants = new ArrayList<>();
+        schemaVariants.add(s -> s);
+        schemaVariants.add(CsvSchema::withComments);
+        schemaVariants.add(s -> s.withEscapeChar('\\'));
+        schemaVariants.add(s -> s.withEscapeChar('\\').withComments());
+        schemaVariants.add(CsvSchema::withoutQuoteChar);
+
+        int count = 0;
+        for (int m = 0; m < mappers.size(); ++m) {
+            CsvMapper mapper = mappers.get(m);
+            for (int v = 0; v < schemaVariants.size(); ++v) {
+                CsvSchema schema = schemaVariants.get(v).apply(SCHEMA);
+                CsvSchema reordered = schemaVariants.get(v).apply(REORDERED);
+                if (mapper.isEnabled(CsvWriteFeature.ESCAPE_CONTROL_CHARS_WITH_ESCAPE_CHAR)
+                        && schema.getEscapeChar() < 0) {
+                    continue; // not a valid combination
+                }
+                for (String value : VALUES) {
+                    String desc = "mode=" + m + " schema=" + v + " value=" + _abbrev(value);
+
+                    // In-order path: String vs char[] (with offset) vs multi-row
+                    String csv = _write(mapper, schema, value);
+                    assertEquals(csv, _writeChars(mapper, schema, value), "char[] " + desc);
+                    assertEquals(csv, _writeMultiRow(mapper, schema, value), "multi-row " + desc);
+
+                    // Buffered (reordered) path: value written second but output first
+                    String csvReordered = _write(mapper, reordered, value);
+                    assertEquals(csvReordered, _writeChars(mapper, reordered, value),
+                            "reordered char[] " + desc);
+
+                    // Round-trip, where reader can be expected to recover value
+                    // (NOTE: with comments enabled, reader skips leading whitespace
+                    // of the first column when looking for comment marker)
+                    if (schema.getQuoteChar() >= 0
+                            && !(schema.allowsComments() && (value.startsWith("#") || value.startsWith(" ")))) {
+                        assertEquals(value, _readValue(mapper, schema, csv), "round-trip " + desc);
+                        assertEquals(value, _readValue(mapper, reordered, csvReordered),
+                                "round-trip reordered " + desc);
+                    }
+                    ++count;
+                }
+            }
+        }
+        assertEquals((mappers.size() * schemaVariants.size() - 3) * VALUES.length, count);
+    }
+
+    // Reads single row back, verifying "id" column and returning "value" column
+    private String _readValue(CsvMapper mapper, CsvSchema schema, String csv) throws Exception
+    {
+        try (MappingIterator<Map<String, String>> it = mapper.readerFor(
+                new TypeReference<Map<String, String>>() { })
+                .with(schema.withoutHeader()).readValues(csv)) {
+            Map<String, String> row = it.nextValue();
+            assertFalse(it.hasNextValue(), "more than one row in: " + _abbrev(csv));
+            assertEquals("id", row.get("id"));
+            return row.get("value");
+        }
+    }
+
+    private static String _abbrev(String s) {
+        return (s.length() > 20) ? s.substring(0, 20) + "...(" + s.length() + ")" : s;
+    }
+
+    /*
+    /**********************************************************************
+    /* Helpers
+    /**********************************************************************
+     */
+
+    private String _write(CsvMapper mapper, CsvSchema schema, String value) throws Exception {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = mapper.writer(schema).createGenerator(sw)) {
+            g.writeStartObject();
+            g.writeName("id");
+            g.writeString("id");
+            g.writeName("value");
+            g.writeString(value);
+            g.writeEndObject();
+        }
+        return sw.toString();
+    }
+
+    private String _writeChars(CsvMapper mapper, CsvSchema schema, String value) throws Exception {
+        // embed in larger array to verify offset handling
+        char[] padded = ("<<" + value + ">>").toCharArray();
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = mapper.writer(schema).createGenerator(sw)) {
+            g.writeStartObject();
+            g.writeName("id");
+            g.writeString("id");
+            g.writeName("value");
+            g.writeString(padded, 2, value.length());
+            g.writeEndObject();
+        }
+        return sw.toString();
+    }
+
+    // Same value written on 3 rows so that the output buffer is partially
+    // full when second and third are written; all rows must be identical
+    private String _writeMultiRow(CsvMapper mapper, CsvSchema schema, String value) throws Exception {
+        StringWriter sw = new StringWriter();
+        try (JsonGenerator g = mapper.writer(schema).createGenerator(sw)) {
+            for (int i = 0; i < 3; ++i) {
+                g.writeStartObject();
+                g.writeName("id");
+                g.writeString("id");
+                g.writeName("value");
+                if ((i & 1) == 0) {
+                    g.writeString(value);
+                } else {
+                    g.writeString(value.toCharArray(), 0, value.length());
+                }
+                g.writeEndObject();
+            }
+        }
+        String all = sw.toString();
+        String first = all.substring(0, all.length() / 3);
+        assertEquals(first + first + first, all, "multi-row rows differ");
+        return first;
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,10 @@ implementations)
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)
+#724: (csv) Single-pass String value writing in `CsvEncoder` (copy into output
+  buffer, then scan for quoting need); `char[]` values no longer converted to
+  `String` unless quoting needed; numeric array elements appended without
+  intermediate `String`
 
 3.2.2 (14-Aug-2026)
 


### PR DESCRIPTION
Follow-up to #721 / #722, covering the remaining CSV generator items.

**1. Single-pass String writes** (`CsvEncoder.appendValue(String)`)
Previously: `_mayNeedQuotes()` scanned the String via `charAt()`, then `writeRaw()` copied it via `getChars()` — two passes for the common no-quoting case. Now the O(1) pre-checks (leading/trailing whitespace, `#` comment marker, loose-mode length cap, empty String) run first; then the content is speculatively copied into the output buffer and the *copy* is scanned. Only if quoting turns out to be needed does the existing `_writeQuoted*()` run, overwriting the speculative copy. `_writeQuoted()` already used this pattern; this brings the unquoted path in line.

`_mayNeedQuotes()` is split into `_needsQuotesWithoutScan()` + `_needsQuoting()` (and kept as their composition, still used for values too long to fit the buffer). `char[]`-region variants of the four scan loops are added. The mode/ordering semantics are preserved exactly — including the existing quirks that `ALWAYS_QUOTE_EMPTY_STRINGS` isn't consulted under `STRICT_CHECK_FOR_QUOTING` or when an escape char is set.

Gain is largest under `STRICT_CHECK_FOR_QUOTING` (full scan of every String); in loose mode the scan is capped at 24 chars so it's a smaller win.

**2. Native `char[]` path** — `write(int, char[], int, int)` (the old `!!! TODO: optimize`) now uses the same approach via `appendValue(char[], int, int)`: `System.arraycopy` + scan; a `String` is only constructed when quoting is required, or when the value must be buffered for column reordering.

**3. Array columns** — `int`/`long`/`double`/`float` elements are appended to the `StringBuilder` directly instead of via `String.valueOf()` (JDK guarantees identical text); `writeString(char[],..)` elements are appended as a range.

Tests: new `CSVStringQuotingModesTest` — hard-coded expectations per mode, plus a 440-combination cross-check (5 feature sets × 5 schema variants × 20 values incl. empty, control chars, non-ASCII, 30-char, 1990-char, and 2500-char values) asserting `writeString(String)`, `writeString(char[],off,len)` (with non-zero offset), multi-row, and reordered/buffered output are identical and round-trip through the parser. `ArrayWriteTest` gains number-array and `char[]`-element cases. Full CSV suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
