### PR TITLE
TOML: lookup table for ASCII string categorization; cheaper writeRaw() variants

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,8 @@ implementations)
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)
+#725: (toml) Use lookup table for ASCII character categorization when writing
+  Strings/keys; avoid `substring()`/`toString()` in `writeRaw()` variants
 
 3.2.2 (14-Aug-2026)
 

--- a/toml/src/main/java/tools/jackson/dataformat/toml/StringOutputUtil.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/StringOutputUtil.java
@@ -12,6 +12,17 @@ class StringOutputUtil {
     public static final int MASK_SIMPLE_KEY = -1; // Should exclude multi-line keys when/if we support them.
     public static final int MASK_STRING = ~UNQUOTED_KEY;
 
+    /**
+     * Pre-computed categories for ASCII range, to avoid evaluating the
+     * full set of checks for every character of every String and key.
+     */
+    private static final int[] ASCII_CATEGORIES = new int[0x80];
+    static {
+        for (int c = 0; c < 0x80; c++) {
+            ASCII_CATEGORIES[c] = _categorize(c);
+        }
+    }
+
     static int categorize(String s) {
         if (s.isEmpty()) {
             return EMPTY_STRING_CATS;
@@ -19,7 +30,9 @@ class StringOutputUtil {
         int flags = -1;
         for (int i = 0; i < s.length();) {
             char hi = s.charAt(i++);
-            if (Character.isHighSurrogate(hi) && i < s.length()) {
+            if (hi < 0x80) { // common case, ASCII
+                flags &= ASCII_CATEGORIES[hi];
+            } else if (Character.isHighSurrogate(hi) && i < s.length()) {
                 char lo = s.charAt(i);
                 if (Character.isLowSurrogate(lo)) {
                     i++;
@@ -41,7 +54,9 @@ class StringOutputUtil {
         int flags = -1;
         for (int i = 0; i < len;) {
             char hi = text[offset + i++];
-            if (Character.isHighSurrogate(hi) && i < len) {
+            if (hi < 0x80) { // common case, ASCII
+                flags &= ASCII_CATEGORIES[hi];
+            } else if (Character.isHighSurrogate(hi) && i < len) {
                 char lo = text[offset + i];
                 if (Character.isLowSurrogate(lo)) {
                     i++;
@@ -57,6 +72,15 @@ class StringOutputUtil {
     }
 
     static int categorize(int c) {
+        if ((c & ~0x7F) == 0) { // ASCII (and not negative)
+            return ASCII_CATEGORIES[c];
+        }
+        return _categorize(c);
+    }
+
+    // Full categorization; used to populate lookup table for ASCII, and
+    // directly for everything else
+    private static int _categorize(int c) {
         if (c > Character.MAX_CODE_POINT || (c >= Character.MIN_SURROGATE && c <= Character.MAX_SURROGATE)) {
             // cannot write surrogates
             return 0;

--- a/toml/src/main/java/tools/jackson/dataformat/toml/TomlGenerator.java
+++ b/toml/src/main/java/tools/jackson/dataformat/toml/TomlGenerator.java
@@ -517,6 +517,17 @@ final class TomlGenerator extends GeneratorBase
 
     @Override
     public JsonGenerator writeRaw(String text, int offset, int len) throws JacksonException {
+        int room = _outputEnd - _outputTail;
+        if (room < len) {
+            _flushBuffer();
+            room = _outputEnd - _outputTail;
+        }
+        if (room >= len) {
+            text.getChars(offset, offset + len, _outputBuffer, _outputTail);
+            _outputTail += len;
+            return this;
+        }
+        // Rare: longer than the output buffer
         return _writeRaw(text.substring(offset, offset + len));
     }
 
@@ -532,7 +543,8 @@ final class TomlGenerator extends GeneratorBase
 
     @Override
     public JsonGenerator writeRaw(SerializableString text) throws JacksonException {
-        return writeRaw(text.toString());
+        // NOTE: `asQuotedChars()` would be JSON-escaped; need unquoted value
+        return _writeRaw(text.getValue());
     }
 
     /*

--- a/toml/src/test/java/tools/jackson/dataformat/toml/StringOutputUtilTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/StringOutputUtilTest.java
@@ -10,6 +10,59 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringOutputUtilTest extends TomlMapperTestBase {
+    // Categorization of a single char via `int`, `String` and `char[]` must agree
+    // (ASCII goes through a lookup table; rest through full logic)
+    @Test
+    public void categorizeConsistency() {
+        char[] buf = new char[3];
+        for (int c = 0; c < 0x10000; c++) {
+            if (Character.isSurrogate((char) c)) {
+                continue; // lone surrogates handled separately below
+            }
+            int expected = StringOutputUtil.categorize(c);
+            String str = String.valueOf((char) c);
+            assertEquals(expected, StringOutputUtil.categorize(str), "String, c=0x" + Integer.toHexString(c));
+            buf[0] = 'x'; buf[1] = (char) c; buf[2] = 'y';
+            assertEquals(expected, StringOutputUtil.categorize(buf, 1, 1), "char[], c=0x" + Integer.toHexString(c));
+        }
+        // lone surrogate: not writable
+        assertEquals(0, StringOutputUtil.categorize("\ud800"));
+        assertEquals(0, StringOutputUtil.categorize(new char[] { '\udc00' }, 0, 1));
+        // surrogate pair: non-ASCII content, allowed in all string types
+        int nonAscii = StringOutputUtil.categorize(0x1F600);
+        assertEquals(nonAscii, StringOutputUtil.categorize("\ud83d\ude00"));
+        assertEquals(nonAscii, StringOutputUtil.categorize(new char[] { 'a', '\ud83d', '\ude00' }, 1, 2));
+        // out of range for `int` variant
+        assertEquals(0, StringOutputUtil.categorize(Character.MAX_CODE_POINT + 1));
+    }
+
+    // Categories of a String are the AND of categories of its characters
+    @Test
+    public void categorizeStrings() {
+        String[] samples = new String[] {
+            "", "abc", "a-b_c9", "a b", "a\"b", "a'b", "a\\b", "a\nb", "\t", "\u007f",
+            "caf\u00e9", "\u65e5\u672c", "\ufeff", "a\ufeffb", "\ud83d\ude00x",
+        };
+        for (String str : samples) {
+            int expected = -1;
+            for (int i = 0; i < str.length();) {
+                int cp = str.codePointAt(i);
+                expected &= StringOutputUtil.categorize(cp);
+                i += Character.charCount(cp);
+            }
+            if (str.isEmpty()) {
+                expected = StringOutputUtil.categorize("");
+            }
+            assertEquals(expected, StringOutputUtil.categorize(str), str);
+            char[] padded = ("<" + str + ">").toCharArray();
+            assertEquals(expected, StringOutputUtil.categorize(padded, 1, str.length()), str);
+        }
+        assertEquals(StringOutputUtil.UNQUOTED_KEY, StringOutputUtil.categorize("abc") & StringOutputUtil.UNQUOTED_KEY);
+        assertEquals(0, StringOutputUtil.categorize("a b") & StringOutputUtil.UNQUOTED_KEY);
+        assertEquals(0, StringOutputUtil.categorize("a'b") & StringOutputUtil.LITERAL_STRING);
+        assertEquals(0, StringOutputUtil.categorize("caf\u00e9") & StringOutputUtil.ASCII_ONLY);
+    }
+
     @Test
     public void exhaustiveWriteReadTest() throws Exception {
         // this test attempts single-character writes for *all* code points, and sees whether they're read back

--- a/toml/src/test/java/tools/jackson/dataformat/toml/TomlGeneratorTest.java
+++ b/toml/src/test/java/tools/jackson/dataformat/toml/TomlGeneratorTest.java
@@ -27,6 +27,32 @@ public class TomlGeneratorTest extends TomlMapperTestBase {
     }
 
     @Test
+    public void rawWrites() {
+        StringWriter w = new StringWriter();
+        try (JsonGenerator generator = newTomlMapper().createGenerator(w)) {
+            generator.writeRaw("xxabc = 1yy", 2, 7);
+            generator.writeRaw('\n');
+            generator.writeRaw(new tools.jackson.core.io.SerializedString("def = \"quoted\""));
+            generator.writeRaw("\n".toCharArray(), 0, 1);
+            // longer than output buffer (2000 chars), via offset/length variant
+            StringBuilder sb = new StringBuilder("<<ghi = '");
+            for (int i = 0; i < 2500; i++) {
+                sb.append('x');
+            }
+            sb.append("'>>");
+            generator.writeRaw(sb.toString(), 2, sb.length() - 4);
+            generator.writeRaw("\n");
+        }
+        String exp = "abc = 1\ndef = \"quoted\"\nghi = '" + "x".repeat(2500) + "'\n";
+        assertEquals(exp, w.toString());
+        // and must be valid TOML
+        JsonNode n = newTomlMapper().readTree(w.toString());
+        assertEquals(1, n.get("abc").intValue());
+        assertEquals("quoted", n.get("def").stringValue());
+        assertEquals(2500, n.get("ghi").stringValue().length());
+    }
+
+    @Test
     public void bool() {
         StringWriter w = new StringWriter();
         try (JsonGenerator generator = newTomlMapper().createGenerator(w)) {


### PR DESCRIPTION
Two small hot-path improvements in the TOML generator.

**`StringOutputUtil.categorize()`** — the per-character category (unquoted-key / literal / basic / basic-no-escape / ASCII-only) was computed via a chain of range checks for every character of every String value and key. ASCII categories are now pre-computed into a 128-entry `int[]` at class init, from the same logic (which stays in place, as `_categorize()`, for non-ASCII, surrogates and BOM). The `String` and `char[]` scanning loops take the ASCII branch before the surrogate check, so the common case is a load-and-AND per char.

**`TomlGenerator.writeRaw()`** — `writeRaw(String, int, int)` allocated via `substring()`; it now does `getChars()` straight into the output buffer, only falling back to the `String` path when the range is longer than the buffer. `writeRaw(SerializableString)` went through `toString()`; now `getValue()`. (3.x's `SerializableString` has no unquoted `char[]` accessor — `asQuotedChars()` is JSON-escaped — so the `String` overload is the right one.)

Tests: `StringOutputUtilTest` gains a consistency check that `int`, `String` and `char[]` categorization agree for every BMP char plus surrogate-pair / lone-surrogate cases, and a per-String AND-of-chars check; the existing exhaustive all-code-points write/read test now runs through the table for ASCII. `TomlGeneratorTest` gains `writeRaw` overload coverage including a >2000-char range. Full TOML suite passes.

While here I noticed a pre-existing bug in `_writeStringImpl(int, char[], int, int)` (`text[offset + len]` instead of `text[offset + i]` in the escaped-basic-string branch). Not touched in this PR — separate fix incoming against 2.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
