### PR TITLE
Avoid `char[]` copy of value text when parsing integer numbers in `CsvDecoder`

### DIFF
--- a/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
+++ b/csv/src/main/java/tools/jackson/dataformat/csv/impl/CsvDecoder.java
@@ -1315,15 +1315,17 @@ public class CsvDecoder
     }
 
     private boolean looksLikeInt() throws JacksonException {
-        final char[] ch = _textBuffer.contentsAsArray();
-        final int len = ch.length;
+        // NOTE: tokenizer has already materialized value as String (see
+        // `_nextUnquotedString()` etc), so access that: no copying needed
+        final String text = _textBuffer.contentsAsString();
+        final int len = text.length();
 
         if (len == 0) {
             return false;
         }
 
         int i = 0;
-        char c = ch[0];
+        char c = text.charAt(0);
         if (c == '-' || c == '+') {
             if (len == 1) {
                 return false;
@@ -1331,7 +1333,7 @@ public class CsvDecoder
             ++i;
         }
         for (; i < len; ++i) {
-            c = ch[i];
+            c = text.charAt(i);
             if (c > '9' || c < '0') {
                 return false;
             }
@@ -1342,32 +1344,23 @@ public class CsvDecoder
     // @since 2.12
     protected void _parseIntValue() throws JacksonException
     {
-        char[] buf = _textBuffer.getTextBuffer();
-        int offset = _textBuffer.getTextOffset();
-        char c = buf[offset];
-        boolean neg;
+        // NOTE: parse directly from String tokenizer has already created,
+        // instead of making a `char[]` copy of it (see `looksLikeInt()`)
+        final String text = _textBuffer.contentsAsString();
+        final char c = text.charAt(0);
+        final boolean neg = (c == '-');
+        final int offset = (neg || (c == '+')) ? 1 : 0;
+        final int len = text.length() - offset;
 
-        if (c == '-') {
-            neg = true;
-            ++offset;
-        } else {
-            neg = false;
-            if (c == '+') {
-                ++offset;
-            }
-        }
-        int len = buf.length - offset;
         if (len <= 9) { // definitely fits in int
-            int i = NumberInput.parseInt(buf, offset, len);
-            _numberInt = neg ? -i : i;
+            // `NumberInput.parseInt(String)` handles leading minus sign but not
+            // plus sign; that is rare enough to just use JDK parsing
+            _numberInt = (c == '+') ? Integer.parseInt(text) : NumberInput.parseInt(text);
             _numTypesValid = NR_INT;
             return;
         }
-        if (len <= 18) { // definitely fits AND is easy to parse using 2 int parse calls
-            long l = NumberInput.parseLong(buf, offset, len);
-            if (neg) {
-                l = -l;
-            }
+        if (len <= 18) { // definitely fits in long
+            long l = Long.parseLong(text);
             // [JACKSON-230] Could still fit in int, need to check
             if (len == 10) {
                 if (neg) {
@@ -1388,7 +1381,7 @@ public class CsvDecoder
             _numTypesValid = NR_LONG;
             return;
         }
-        _parseSlowIntValue(buf, offset, len, neg);
+        _parseSlowIntValue(text, offset, neg);
     }
 
     private final void _parseSlowFloatValue(boolean exactNumber)
@@ -1417,14 +1410,14 @@ public class CsvDecoder
         }
     }
 
-    private final void _parseSlowIntValue(char[] buf, int offset, int len,
-            boolean neg)
+    // Called for 19 or more digits: may still fit in `long`
+    private final void _parseSlowIntValue(String numStr, int offset, boolean neg)
         throws JacksonException
     {
-        String numStr = _textBuffer.contentsAsString();
         try {
-            if (NumberInput.inLongRange(buf, offset, len, neg)) {
-                // Probably faster to construct a String, call parse, than to use BigInteger
+            // `inLongRange()` needs digits without sign
+            final String digits = (offset == 0) ? numStr : numStr.substring(offset);
+            if (NumberInput.inLongRange(digits, neg)) {
                 _numberLong = Long.parseLong(numStr);
                 _numTypesValid = NR_LONG;
             } else {

--- a/csv/src/test/java/tools/jackson/dataformat/csv/deser/CsvDecoderNumberTest.java
+++ b/csv/src/test/java/tools/jackson/dataformat/csv/deser/CsvDecoderNumberTest.java
@@ -90,6 +90,79 @@ public class CsvDecoderNumberTest extends ModuleTestBase
         }
     }
 
+    // Boundaries between int / long / BigInteger parsing paths (by digit
+    // count and by value), with and without signs, leading zeroes
+    @Test
+    public void testIntegerBoundaries() throws Exception
+    {
+        _assertInt("0", 0);
+        _assertInt("-0", 0);
+        _assertInt("+7", 7);
+        _assertInt("000000001", 1);
+        _assertInt("999999999", 999999999); // 9 digits
+        _assertInt("1000000000", 1000000000); // 10 digits, fits int
+        _assertInt("2147483647", Integer.MAX_VALUE);
+        _assertInt("+2147483647", Integer.MAX_VALUE);
+        _assertInt("-2147483648", Integer.MIN_VALUE);
+        // NOTE: type chosen by digit count; leading zeroes push into long path
+        _assertLong("-000002147483648", Integer.MIN_VALUE);
+
+        _assertLong("2147483648", 2147483648L); // 10 digits, does not fit int
+        _assertLong("-2147483649", -2147483649L);
+        _assertLong("999999999999999999", 999999999999999999L); // 18 digits
+        _assertLong("-999999999999999999", -999999999999999999L);
+        _assertLong("1000000000000000000", 1000000000000000000L); // 19 digits
+        _assertLong("9223372036854775807", Long.MAX_VALUE);
+        _assertLong("+9223372036854775807", Long.MAX_VALUE);
+        _assertLong("-9223372036854775808", Long.MIN_VALUE);
+        _assertBigInteger("0009223372036854775807"); // in long range, but >19 digits
+
+        _assertBigInteger("9223372036854775808"); // Long.MAX_VALUE + 1
+        _assertBigInteger("-9223372036854775809"); // Long.MIN_VALUE - 1
+        _assertBigInteger("+9223372036854775808");
+        _assertBigInteger("12345678901234567890");
+        _assertBigInteger("-123456789012345678901234567890");
+    }
+
+    @Test
+    public void testNotInts() throws Exception
+    {
+        for (String value : new String[] { "", " ", "-", "+", "1.0", "1e5", "0x10", "12a", "1 2", "--1", "+-1" }) {
+            try (JsonParser p = MAPPER.reader(SCHEMA).createParser("\"" + value + "\"\n")) {
+                assertToken(JsonToken.START_OBJECT, p.nextToken());
+                assertToken(JsonToken.PROPERTY_NAME, p.nextToken());
+                assertToken(JsonToken.VALUE_STRING, p.nextToken());
+                assertFalse(p.isExpectedNumberIntToken(), "Should not be number-int: '" + value + "'");
+                assertToken(JsonToken.VALUE_STRING, p.currentToken());
+                assertEquals(value, p.getString());
+            }
+        }
+    }
+
+    private void _assertInt(String text, int exp) throws Exception {
+        try (JsonParser p = _intValueParser(text)) {
+            assertEquals(NumberType.INT, p.getNumberType(), text);
+            assertEquals(exp, p.getIntValue(), text);
+            assertEquals(Integer.valueOf(exp), p.getNumberValue(), text);
+            assertEquals(text, p.getString());
+        }
+    }
+
+    private void _assertLong(String text, long exp) throws Exception {
+        try (JsonParser p = _intValueParser(text)) {
+            assertEquals(NumberType.LONG, p.getNumberType(), text);
+            assertEquals(exp, p.getLongValue(), text);
+            assertEquals(Long.valueOf(exp), p.getNumberValue(), text);
+        }
+    }
+
+    private void _assertBigInteger(String text) throws Exception {
+        try (JsonParser p = _intValueParser(text)) {
+            assertEquals(NumberType.BIG_INTEGER, p.getNumberType(), text);
+            assertEquals(new BigInteger(text), p.getBigIntegerValue(), text);
+        }
+    }
+
     /*
     /**********************************************************************
     /* Overflow handling

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,8 @@ implementations)
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)
+#727: (csv) Avoid `char[]` copy of value text when parsing integer numbers
+  in `CsvDecoder` (parse directly from already-materialized `String`)
 
 3.2.2 (14-Aug-2026)
 


### PR DESCRIPTION
Read-side counterpart to #721/#724.

`CsvDecoder.looksLikeInt()` began with `_textBuffer.contentsAsArray()`. Because the tokenizer has already materialized the column value as a `String` (`finishAndReturn()` → `contentsAsString()`), that call is `_resultString.toCharArray()` — a fresh copy of the token. `_parseIntValue()` then depended on that copy being exact-size (`int len = buf.length - offset`). Net effect: every numeric column accessed via `isExpectedNumberIntToken()` — which is how databind reads `int`/`long`/`BigInteger` properties from CSV — allocated a `char[]` before parsing.

Both methods now work on the `String` directly:
- `looksLikeInt()` scans via `charAt()`
- `_parseIntValue()` uses `NumberInput.parseInt(String)` (≤9 digits; JDK `Integer.parseInt` only for the rare `+` prefix, which `NumberInput` doesn't handle), `Long.parseLong` (10–18 digits, then the existing exactly-10-digit `int` narrowing), and `_parseSlowIntValue()` uses `NumberInput.inLongRange(String, neg)` for 19+ digits — the one remaining allocation is a `substring()` to strip the sign for that unsigned check, on 19+ digit signed values only
- the BigInteger path is unchanged (still lazy via `_numberString`)

The digit-count based selection of `int`/`long`/`BigInteger` is preserved exactly (e.g. `-000002147483648` is still reported as `LONG`, 22-char values in `long` range still go to `BigInteger`).

Side note: `contentsAsDouble()` already parsed from `_resultString`, so the float path had no copy — nothing to change there. TOML is already fully on `NumberInput` (including `parseLong19`/`inLongRange` on `char[]`); Properties doesn't parse numbers itself.

Tests: `CsvDecoderNumberTest` gains boundary cases for each branch — 9/10/18/19-digit values on both sides of the `int` and `long` limits, `+`/`-` signs, leading zeroes, `Long.MIN/MAX_VALUE ± 1` — plus a set of near-miss non-integers (`""`, `"-"`, `"1.0"`, `"1e5"`, `"0x10"`, `"--1"`…) that must stay `VALUE_STRING`. Full CSV suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
