### PR TITLE
Support StreamReadConstraints.maxDocumentLength() in YAML parser

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -16,6 +16,7 @@ implementations)
 
 3.3.0 (not yet released)
 
+#636: (yaml) Support `StreamReadConstraints.maxDocumentLength()` for YAML parser
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/YAMLParser.java
@@ -15,6 +15,8 @@ import tools.jackson.core.util.BufferRecycler;
 import tools.jackson.core.util.JacksonFeatureSet;
 import tools.jackson.core.util.SimpleStreamReadContext;
 
+import tools.jackson.dataformat.yaml.util.ReadConstrainedReader;
+
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.common.Anchor;
 import org.snakeyaml.engine.v2.events.AliasEvent;
@@ -149,6 +151,11 @@ public class YAMLParser extends ParserBase
         }
         _formatFeatures = formatFeatures;
         _reader = reader;
+        // [dataformats-text#636]: SnakeYAML reads input directly, so to enforce
+        // max document length we need to count what it reads
+        if (_streamReadConstraints.hasMaxDocumentLength()) {
+            reader = new ReadConstrainedReader(reader, _streamReadConstraints);
+        }
         _yamlParser = new ParserImpl(loadSettings, new StreamReader(loadSettings, reader));
         _yamlResolver = loadSettings.getSchema().getScalarResolver();
 

--- a/yaml/src/main/java/tools/jackson/dataformat/yaml/util/ReadConstrainedReader.java
+++ b/yaml/src/main/java/tools/jackson/dataformat/yaml/util/ReadConstrainedReader.java
@@ -1,0 +1,80 @@
+package tools.jackson.dataformat.yaml.util;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+/**
+ * {@link Reader} decorator that enforces
+ * {@link StreamReadConstraints#getMaxDocumentLength()} by counting characters
+ * read through it. Needed since actual YAML decoding is done by SnakeYAML
+ * Engine, reading content directly from a {@link Reader}, so the parser
+ * itself does not see input as it is consumed.
+ *<p>
+ * Should only be used when constraints define a maximum document length
+ * (see {@link StreamReadConstraints#hasMaxDocumentLength()}).
+ *
+ * @since 3.3
+ */
+public class ReadConstrainedReader extends Reader
+{
+    private final Reader _delegate;
+
+    private final StreamReadConstraints _constraints;
+
+    /**
+     * Total number of characters read (or skipped) so far.
+     */
+    private long _charsRead;
+
+    public ReadConstrainedReader(Reader delegate, StreamReadConstraints constraints) {
+        _delegate = delegate;
+        _constraints = constraints;
+    }
+
+    public long charsRead() {
+        return _charsRead;
+    }
+
+    private void _count(long n) throws StreamConstraintsException {
+        if (n > 0) {
+            _charsRead += n;
+            _constraints.validateDocumentLength(_charsRead);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        int c = _delegate.read();
+        if (c >= 0) {
+            _count(1);
+        }
+        return c;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        int n = _delegate.read(cbuf, off, len);
+        _count(n);
+        return n;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long skipped = _delegate.skip(n);
+        _count(skipped);
+        return skipped;
+    }
+
+    @Override
+    public boolean ready() throws IOException {
+        return _delegate.ready();
+    }
+
+    @Override
+    public void close() throws IOException {
+        _delegate.close();
+    }
+}

--- a/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/YAMLDocumentLengthTest.java
+++ b/yaml/src/test/java/tools/jackson/dataformat/yaml/constraints/YAMLDocumentLengthTest.java
@@ -1,0 +1,145 @@
+package tools.jackson.dataformat.yaml.constraints;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+import tools.jackson.databind.JsonNode;
+
+import tools.jackson.dataformat.yaml.ModuleTestBase;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link StreamReadConstraints#getMaxDocumentLength()} enforcement
+ * in YAML parsing: since SnakeYAML Engine reads input directly, this is done
+ * by counting characters it reads.
+ *
+ * @see <a href="https://github.com/FasterXML/jackson-dataformats-text/issues/636">[dataformats-text#636]</a>
+ */
+public class YAMLDocumentLengthTest extends ModuleTestBase
+{
+    private final static int MAX_DOC_LEN = 10_000;
+
+    private static YAMLFactory factoryWithDocLimit(long limit) {
+        return YAMLFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxDocumentLength(limit).build())
+                .build();
+    }
+
+    private final YAMLMapper LIMITED_MAPPER = new YAMLMapper(factoryWithDocLimit(MAX_DOC_LEN));
+
+    @Test
+    public void testDocumentWithinLimit() throws Exception
+    {
+        final String doc = _generateYaml(MAX_DOC_LEN - 100);
+        _verifyReadable(LIMITED_MAPPER, doc);
+    }
+
+    @Test
+    public void testDocumentExceedingLimit() throws Exception
+    {
+        final String doc = _generateYaml(MAX_DOC_LEN + 500);
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(new StringReader(doc)));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8))));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc.getBytes(StandardCharsets.UTF_8)));
+        // Streaming access too
+        _verifyDocTooLong(() -> {
+            try (JsonParser p = factoryWithDocLimit(MAX_DOC_LEN).createParser(ObjectReadContext.empty(), doc)) {
+                while (p.nextToken() != null) { }
+            }
+        });
+        // And sanity check: fine with default constraints
+        _verifyReadable(newObjectMapper(), doc);
+    }
+
+    // Limit smaller than SnakeYAML's read buffer: must still be enforced
+    @Test
+    public void testSmallLimit() throws Exception
+    {
+        YAMLMapper mapper = new YAMLMapper(factoryWithDocLimit(100));
+        _verifyReadable(mapper, _generateYaml(50));
+        _verifyDocTooLong(() -> mapper.readTree(_generateYaml(200)));
+    }
+
+    // Single scalar value longer than limit
+    @Test
+    public void testLongScalar() throws Exception
+    {
+        final String doc = "key: " + "x".repeat(MAX_DOC_LEN + 500) + "\n";
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc));
+        // (and it is document length, not String length, that fails)
+        assertEquals(MAX_DOC_LEN + 500, newObjectMapper().readTree(doc).get("key").stringValue().length());
+    }
+
+    // Multiple documents in one stream: limit applies to whole stream
+    @Test
+    public void testMultipleDocuments() throws Exception
+    {
+        final String one = _generateYaml(MAX_DOC_LEN / 2);
+        final String docs = one + "---\n" + one + "---\n" + one;
+        try (JsonParser p = factoryWithDocLimit(MAX_DOC_LEN).createParser(ObjectReadContext.empty(), docs)) {
+            assertNotNull(p.nextToken()); // first doc starts fine
+            _verifyDocTooLong(() -> { while (p.nextToken() != null) { } });
+        }
+    }
+
+    // No limit configured: nothing is counted or enforced
+    @Test
+    public void testNoLimit() throws Exception
+    {
+        YAMLFactory f = YAMLFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxDocumentLength(-1L).build())
+                .build();
+        assertFalse(f.streamReadConstraints().hasMaxDocumentLength());
+        _verifyReadable(new YAMLMapper(f), _generateYaml(MAX_DOC_LEN * 3));
+    }
+
+    /*
+    /**********************************************************************
+    /* Helpers
+    /**********************************************************************
+     */
+
+    private interface ThrowingRunnable { void run() throws Exception; }
+
+    private void _verifyDocTooLong(ThrowingRunnable r) throws Exception
+    {
+        try {
+            r.run();
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Document length");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+    }
+
+    private void _verifyReadable(YAMLMapper mapper, String doc) throws Exception
+    {
+        JsonNode n = mapper.readTree(doc);
+        assertTrue(n.isObject() && n.size() > 0);
+        assertEquals(n, mapper.readTree(new StringReader(doc)));
+        assertEquals(n, mapper.readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.UTF_8))));
+        assertEquals(n, mapper.readTree(doc.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static String _generateYaml(int targetLen) {
+        StringBuilder sb = new StringBuilder(targetLen + 32);
+        int i = 0;
+        while (sb.length() < targetLen) {
+            sb.append("key").append(i++).append(": \"value\"\n");
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Completes #636 (which delivered `maxNameLength`; `maxDocumentLength` was left out because SnakeYAML consumes the input). Same approach as TOML in #728: count at the input boundary.

`YAMLParser` hands SnakeYAML Engine a `Reader` (`new StreamReader(loadSettings, reader)`). When `StreamReadConstraints.hasMaxDocumentLength()`, that `Reader` is now wrapped in a small `ReadConstrainedReader` (`yaml.util`) that accumulates characters read/skipped and calls `validateDocumentLength()` after each read. When no limit is configured (the default) nothing is wrapped, so there's zero overhead; with a limit it's one `long` add + compare per buffer fill. Since every `_createParser` variant ends up passing a `Reader` (byte input goes through `UTF8Reader`), this covers `String`, `Reader`, `InputStream`, `byte[]` and `char[]` input in one place.

Note the limit applies to the whole stream, including multi-document YAML streams — same as for JSON's `MappingIterator` over a stream.

Tests: `YAMLDocumentLengthTest` — within/over the limit for all input types plus direct streaming access; a limit below SnakeYAML's read buffer size; a single scalar longer than the limit (fails on document length, not string length); multi-document streams; and explicit no-limit. Full YAML suite passes (273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
