### PR TITLE
Support StreamReadConstraints.maxDocumentLength() in Properties parser

### DIFF
--- a/properties/src/main/java/tools/jackson/dataformat/javaprop/JavaPropsFactory.java
+++ b/properties/src/main/java/tools/jackson/dataformat/javaprop/JavaPropsFactory.java
@@ -10,6 +10,7 @@ import tools.jackson.core.io.IOContext;
 import tools.jackson.dataformat.javaprop.impl.PropertiesBackedGenerator;
 import tools.jackson.dataformat.javaprop.impl.WriterBackedGenerator;
 import tools.jackson.dataformat.javaprop.io.Latin1Reader;
+import tools.jackson.dataformat.javaprop.io.ReadConstrainedReader;
 
 @SuppressWarnings("resource")
 public class JavaPropsFactory
@@ -301,6 +302,12 @@ public class JavaPropsFactory
 
     protected Properties _loadProperties(Reader r0, IOContext ctxt)
     {
+        // [dataformats-text#638]: `Properties.load()` reads input directly, so
+        // to enforce max document length we need to count what it reads
+        final StreamReadConstraints src = ctxt.streamReadConstraints();
+        if (src.hasMaxDocumentLength()) {
+            r0 = new ReadConstrainedReader(r0, src);
+        }
         Properties props = new Properties();
         // May or may not want to close the reader, so...
         try {

--- a/properties/src/main/java/tools/jackson/dataformat/javaprop/io/ReadConstrainedReader.java
+++ b/properties/src/main/java/tools/jackson/dataformat/javaprop/io/ReadConstrainedReader.java
@@ -1,0 +1,80 @@
+package tools.jackson.dataformat.javaprop.io;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+/**
+ * {@link Reader} decorator that enforces
+ * {@link StreamReadConstraints#getMaxDocumentLength()} by counting characters
+ * read through it. Needed since actual decoding is done by
+ * {@link java.util.Properties#load(Reader)}, reading content directly from
+ * a {@link Reader}, so the parser itself does not see input as it is consumed.
+ *<p>
+ * Should only be used when constraints define a maximum document length
+ * (see {@link StreamReadConstraints#hasMaxDocumentLength()}).
+ *
+ * @since 3.3
+ */
+public class ReadConstrainedReader extends Reader
+{
+    private final Reader _delegate;
+
+    private final StreamReadConstraints _constraints;
+
+    /**
+     * Total number of characters read (or skipped) so far.
+     */
+    private long _charsRead;
+
+    public ReadConstrainedReader(Reader delegate, StreamReadConstraints constraints) {
+        _delegate = delegate;
+        _constraints = constraints;
+    }
+
+    public long charsRead() {
+        return _charsRead;
+    }
+
+    private void _count(long n) throws StreamConstraintsException {
+        if (n > 0) {
+            _charsRead += n;
+            _constraints.validateDocumentLength(_charsRead);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        int c = _delegate.read();
+        if (c >= 0) {
+            _count(1);
+        }
+        return c;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        int n = _delegate.read(cbuf, off, len);
+        _count(n);
+        return n;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long skipped = _delegate.skip(n);
+        _count(skipped);
+        return skipped;
+    }
+
+    @Override
+    public boolean ready() throws IOException {
+        return _delegate.ready();
+    }
+
+    @Override
+    public void close() throws IOException {
+        _delegate.close();
+    }
+}

--- a/properties/src/test/java/tools/jackson/dataformat/javaprop/constraints/PropsDocumentLengthTest.java
+++ b/properties/src/test/java/tools/jackson/dataformat/javaprop/constraints/PropsDocumentLengthTest.java
@@ -1,0 +1,132 @@
+package tools.jackson.dataformat.javaprop.constraints;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.exc.StreamConstraintsException;
+
+import tools.jackson.databind.JsonNode;
+
+import tools.jackson.dataformat.javaprop.JavaPropsFactory;
+import tools.jackson.dataformat.javaprop.JavaPropsMapper;
+import tools.jackson.dataformat.javaprop.ModuleTestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link StreamReadConstraints#getMaxDocumentLength()} enforcement
+ * in Properties parsing: since {@code java.util.Properties.load()} reads input
+ * directly, this is done by counting characters it reads.
+ *
+ * @see <a href="https://github.com/FasterXML/jackson-dataformats-text/issues/638">[dataformats-text#638]</a>
+ */
+public class PropsDocumentLengthTest extends ModuleTestBase
+{
+    private final static int MAX_DOC_LEN = 10_000;
+
+    private static JavaPropsFactory factoryWithDocLimit(long limit) {
+        return JavaPropsFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                        .maxDocumentLength(limit).build())
+                .build();
+    }
+
+    private final JavaPropsMapper LIMITED_MAPPER = new JavaPropsMapper(factoryWithDocLimit(MAX_DOC_LEN));
+
+    @Test
+    public void testDocumentWithinLimit() throws Exception
+    {
+        _verifyReadable(LIMITED_MAPPER, _generateProps(MAX_DOC_LEN - 100));
+    }
+
+    @Test
+    public void testDocumentExceedingLimit() throws Exception
+    {
+        final String doc = _generateProps(MAX_DOC_LEN + 500);
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(new StringReader(doc)));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.ISO_8859_1))));
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc.getBytes(StandardCharsets.ISO_8859_1)));
+        // Streaming access: parser construction already loads properties
+        _verifyDocTooLong(() -> {
+            try (JsonParser p = factoryWithDocLimit(MAX_DOC_LEN).createParser(ObjectReadContext.empty(), doc)) {
+                while (p.nextToken() != null) { }
+            }
+        });
+        // And sanity check: fine with default constraints
+        _verifyReadable(newPropertiesMapper(), doc);
+    }
+
+    // Limit smaller than `Properties.load()` read buffer (8k): must still be enforced
+    @Test
+    public void testSmallLimit() throws Exception
+    {
+        JavaPropsMapper mapper = new JavaPropsMapper(factoryWithDocLimit(100));
+        _verifyReadable(mapper, _generateProps(50));
+        _verifyDocTooLong(() -> mapper.readTree(_generateProps(200)));
+    }
+
+    // Single value longer than limit
+    @Test
+    public void testLongValue() throws Exception
+    {
+        final String doc = "key=" + "x".repeat(MAX_DOC_LEN + 500) + "\n";
+        _verifyDocTooLong(() -> LIMITED_MAPPER.readTree(doc));
+        // (and it is document length, not String length, that fails)
+        assertEquals(MAX_DOC_LEN + 500, newPropertiesMapper().readTree(doc).get("key").stringValue().length());
+    }
+
+    // No limit configured: nothing is counted or enforced
+    @Test
+    public void testNoLimit() throws Exception
+    {
+        JavaPropsFactory f = JavaPropsFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxDocumentLength(-1L).build())
+                .build();
+        assertFalse(f.streamReadConstraints().hasMaxDocumentLength());
+        _verifyReadable(new JavaPropsMapper(f), _generateProps(MAX_DOC_LEN * 3));
+    }
+
+    /*
+    /**********************************************************************
+    /* Helpers
+    /**********************************************************************
+     */
+
+    private interface ThrowingRunnable { void run() throws Exception; }
+
+    private void _verifyDocTooLong(ThrowingRunnable r) throws Exception
+    {
+        try {
+            r.run();
+            fail("expected StreamConstraintsException");
+        } catch (StreamConstraintsException e) {
+            verifyException(e, "Document length");
+            verifyException(e, "exceeds the maximum allowed");
+        }
+    }
+
+    private void _verifyReadable(JavaPropsMapper mapper, String doc) throws Exception
+    {
+        JsonNode n = mapper.readTree(doc);
+        assertTrue(n.isObject() && n.size() > 0);
+        assertEquals(n, mapper.readTree(new StringReader(doc)));
+        assertEquals(n, mapper.readTree(new ByteArrayInputStream(doc.getBytes(StandardCharsets.ISO_8859_1))));
+        assertEquals(n, mapper.readTree(doc.getBytes(StandardCharsets.ISO_8859_1)));
+    }
+
+    private static String _generateProps(int targetLen) {
+        StringBuilder sb = new StringBuilder(targetLen + 32);
+        int i = 0;
+        while (sb.length() < targetLen) {
+            sb.append("key").append(i++).append("=value\n");
+        }
+        return sb.toString();
+    }
+}

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -16,6 +16,8 @@ implementations)
 
 3.3.0 (not yet released)
 
+#638: (properties) Support `StreamReadConstraints.maxDocumentLength()` for
+  Properties parser
 #699: (csv) Ability to modify columns in `CsvSchema.Builder` by name
  (requested by @OrangeDog)
  (fix by @seonwooj0810)


### PR DESCRIPTION
Completes #638 (which delivered `maxNameLength`; `maxDocumentLength` was left out because `java.util.Properties.load()` consumes the input). Same approach as TOML (#728) and YAML (#729): count at the input boundary.

Every `_createParser` variant in `JavaPropsFactory` funnels through `_loadProperties(Reader, IOContext)` (`InputStream` input via `Latin1Reader`, `byte[]`/`char[]` via `Latin1Reader`/`CharArrayReader`), so that single method now wraps the `Reader` in a small `ReadConstrainedReader` (`javaprop.io`) when `StreamReadConstraints.hasMaxDocumentLength()`. The wrapper accumulates characters read/skipped and calls `validateDocumentLength()` after each read; with no limit configured (the default) nothing is wrapped, so there's zero overhead. The `try-with-resources` close still closes the underlying reader through the wrapper.

Tests: `PropsDocumentLengthTest` — within/over the limit for `String`, `Reader`, `InputStream` and `byte[]` input plus direct streaming access; a limit below `Properties.load()`'s 8K read buffer; a single value longer than the limit (fails on document length, not string length); explicit no-limit. Full Properties suite passes (77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
